### PR TITLE
Typo NOLI ME TANGERE, not NOLI SE TANGERE

### DIFF
--- a/Luminary099/BURN_BABY_BURN--MASTER_IGNITION_ROUTINE.agc
+++ b/Luminary099/BURN_BABY_BURN--MASTER_IGNITION_ROUTINE.agc
@@ -69,7 +69,7 @@
 #		TABLES FOR THE IGNITION ROUTINE
 #	***********************************************
 #
-#			NOLI SE TANGERE
+#			NOLI ME TANGERE
 
 P12TABLE	VN	0674		# (0)
 		TCF	ULLGNOT		# (1)


### PR DESCRIPTION
If my italian is any good, they meant to say

TOUCH ME NOT 
DON'T TOUCH ME

Whereas they actually wrote something along the lines of

TOUCH YOU NOT