### PR TITLE
Update README.es.md

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -18,14 +18,7 @@ Español,
 [ZH_CN]:README.zh_cn.md
 [KO_KR]:README.ko_kr.md
 
-Código fuente original del ordenador de abordo del Apollo 11 (AGC)
-para el módulo de órdenes (Comanche055) y el módulo lunar (Luminary099).
-Digitalizado por los amigos de [Virtual AGC][3] y [el museo del MIT][4].
-El objetivo es ser un repositorio del código fuente original del Apollo 11.
-De este modo, las PRs serán bienvenidas para cualquier cuestión que se
-identifique entre las transcripciones en este repositorio y los escaneos
-del código fuente original para [Luminary 099][5] y
-[Comanche 055][6], así como cualquier fichero que se haya olvidado.
+Código fuente original del ordenador de guía de la Apollo 11 (AGC) para el módulo de comando (Comanche055) y el módulo lunar (Luminary099). Digitalizado por los amigos de [Virtual AGC][3] y [el museo del MIT][4]. El objetivo es ser un repositorio del código fuente original de la Apollo 11. De este modo, las PRs serán bienvenidas para cualquier cuestión que se identifique entre las transcripciones en este repositorio y los escaneos del código fuente original para [Luminary 099][5] y [Comanche 055][6], así como cualquier fichero que se haya olvidado.
 
 ## Cómo contribuir
 Por favor, lea [CONTRIBUTING.md][7] antes de abrir una pull request.
@@ -39,34 +32,25 @@ Si está interesado en compilar el código fuente original, eche un vistazo a
 &nbsp;            | &nbsp;
 :---------------- | :-----
 Derechos de autor | Dominio público
-Comanche055       | Part of the source code for Colossus 2A, the Command Module's (CM) Apollo Guidance Computer (AGC) for Apollo 11<br>`Assemble revision 055 of AGC program Comanche by NASA`<br>`2021113-051. 10:28 APR. 1, 1969`
-Luminary099       | Part of the source code for Luminary 1A, the Lunar Module's (LM) Apollo Guidance Computer (AGC) for Apollo 11<br>`Assemble revision 001 of AGC program LYM99 by NASA`<br>`2021112-061. 16:27 JUL. 14, 1969`
+Comanche055       | Parte del código fuente de Colossus 2A, el Ordenador de Guía para la Apollo (AGC) del Módulo de Comando (CM) para la Apollo 11<br>`Assemble revision 055 of AGC program Comanche by NASA`<br>`2021113-051. 10:28 APR. 1, 1969`
+Luminary099       | Parte del código fuente de Luminary 1A, el Ordenador de Guía para la Apollo (AGC) del Módulo Lunar (LM) para la Apollo 11<br>`Assemble revision 001 of AGC program LYM99 by NASA`<br>`2021112-061. 16:27 JUL. 14, 1969`
 Ensamblador       | yaYUL
 Contacto          | Ron Burkey <info@sandroid.org>
 Sitio Web         | www.ibiblio.org/apollo
-Digitalización    | Este código fuente se ha transcrito o adaptado de imágenes digitalizadas de una copia en papel presente en el museo del MIT. Los empleados del museo Paul Fjeld y Deborah Douglas relizaron la digitalización y la gestión de las imágenes respectivamente. Muchas gracias a ambos.
+Digitalización    | Este código fuente se ha transcrito o adaptado de imágenes digitalizadas de una copia en papel presente en el museo del MIT. Los empleados del museo Paul Fjeld y Deborah Douglas realizaron la digitalización y la gestión de las imágenes respectivamente. Muchas gracias a ambos.
 
 ### Contract and Approvals
 *Derivado de [CONTRACT_AND_APPROVALS.agc]*
 
-```plain
-ESTE PROGRMA DEBE TAMBIÉN LLAMARSE:
-    COLOSSUS 2A*
+Este programa debe también llamarse Colossus 2A.
 
-ESTE PROGRMA SE CREÓ PARA UTILIZARSE EN EL CM TAL Y COMO
-SE ESPECIFICA EN EL INFORME R-577.  ESTE PROGRMA SE PREPARÓ
-EN EL PROYECTO DSR 55-23870, ESPONSORIZADO POR EL CENTRO DE
-NAVES TRIPULADAS DEL CENTRO NACIONAL DE AERONAÚTICA Y
-ADMINISTRACIÓN ESPACIAL A TRAVÉS DEL CONTACTO NAS 9-4065
-DEL LABORATORIO DE INSTRUMENTACIÓN DEL INSTITUTO DE TECNOLOGÍA
-DE MASSACHUSSETS, CAMBRIDGE, MASS.
-```
+Este programa se creó para utilizarse en el CM tal y como se especifica en el informe `R-577`. Este programa se preparó en el proyecto `55-23870`, esponsorizado por el Centro de Naves Tripuladas del Centro Nacional de Aeronáutica y Administración Espacial a través del contrato `NAS 9-4065` del Laboratorio de Instrumentación del Instituto de Tecnología de Massachussets, Cambridge, Mass.
 
-Enviado por           | Role | Fecha
+Enviado por           | Rol | Fecha
 :-------------------- | :--- | :----
 Margaret H. Hamilton  | Colossus Programming Leader<br>Apollo Guidance and Navigation | 28 Mar 69
 
-Apronado por       | Role | Fecha
+Aprobado por       | Rol | Fecha
 :----------------- | :--- | :----
 Daniel J. Lickly   | Director, Mission Program Development<br>Apollo Guidance and Navigation Program | 28 Mar 69
 Fred H. Martin     | Colossus Project Manager<br>Apollo Guidance and Navigation Program | 28 Mar 69


### PR DESCRIPTION
Added corrections and suggestions from PR #332,  also found the way AGC is called in spanish according to an [interview (content in spanish)][1] to the argentinian Ramon Alonso, who defined its architecture. 


[1]:https://www.lanacion.com.ar/1240769-ramon-alonso-el-argentino-que-llevo-a-la-apollo-11-a-la-luna   