### PR TITLE
Include a german readme

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -50,7 +50,7 @@ Luminary099     | Teil des Quellcodes für Luminary 1A, den Apollo Navigationsco
 Assembler       | yaYUL
 Kontakt         | Ron Burkey <info@sandroid.org>
 Webseite        | www.ibiblio.org/apollo
-Digitalisierung | Der vorliegende Quellcode wurde von digitalisierten Bildern einer physischen Kopie des MIT Museums transkribiert oder anderweitig adaptiert. Die Digitalisierung wurde furchgeführt von Paul Fjeld nach Vorbereitung von Deborah Douglas vom MIT Museum. Vielen Dank an beide.
+Digitalisierung | Der vorliegende Quellcode wurde von digitalisierten Bildern einer physischen Kopie des MIT Museums transkribiert oder anderweitig adaptiert. Die Digitalisierung wurde durchgeführt von Paul Fjeld nach Vorbereitung von Deborah Douglas vom MIT Museum. Vielen Dank an beide.
 
 ### Vertrag und Genehmigungen
 *Abgeleitet aus [CONTRACT_AND_APPROVALS.agc]*

--- a/README.de.md
+++ b/README.de.md
@@ -42,15 +42,15 @@ wirf am besten einen Blick auf das [Virtual AGC][8] Projekt.
 
 ## Attribution
 
-&nbsp;         | &nbsp;
-:------------- | :-----
-Copyright      | Gemeingut
-Comanche055    | Teil des Quellcodes für Colossus 2A, den Apollo Navigationscomputer (AGC) des Kommandomoduls (CM) für Apollo 11<br>`Assemble revision 055 of AGC program Comanche by NASA`<br>`2021113-051. 10:28 APR. 1, 1969`
-Luminary099    | Teil des Quellcodes für Luminary 1A, den Apollo Navigationscomputer (AGC) der Mondlandefähre (LM) für Apollo 11<br>`Assemble revision 001 of AGC program LYM99 by NASA`<br>`2021112-061. 16:27 JUL. 14, 1969`
-Assembler      | yaYUL
-Contact        | Ron Burkey <info@sandroid.org>
-Website        | www.ibiblio.org/apollo
-Digitalization | Der vorliegende Quellcode wurde von digitalisierten Bildern einer physischen Kopie des MIT Museums transkribiert oder anderweitig adaptiert. Die Digitalisierung wurde furchgeführt von Paul Fjeld nach Vorbereitung von Deborah Douglas vom MIT Museum. Vielen Dank an beide.
+&nbsp;          | &nbsp;
+:-------------- | :-----
+Copyright       | Gemeingut
+Comanche055     | Teil des Quellcodes für Colossus 2A, den Apollo Navigationscomputer (AGC) des Kommandomoduls (CM) für Apollo 11<br>`Assemble revision 055 of AGC program Comanche by NASA`<br>`2021113-051. 10:28 APR. 1, 1969`
+Luminary099     | Teil des Quellcodes für Luminary 1A, den Apollo Navigationscomputer (AGC) der Mondlandefähre (LM) für Apollo 11<br>`Assemble revision 001 of AGC program LYM99 by NASA`<br>`2021112-061. 16:27 JUL. 14, 1969`
+Assembler       | yaYUL
+Kontakt         | Ron Burkey <info@sandroid.org>
+Webseite        | www.ibiblio.org/apollo
+Digitalisierung | Der vorliegende Quellcode wurde von digitalisierten Bildern einer physischen Kopie des MIT Museums transkribiert oder anderweitig adaptiert. Die Digitalisierung wurde furchgeführt von Paul Fjeld nach Vorbereitung von Deborah Douglas vom MIT Museum. Vielen Dank an beide.
 
 ### Vertrag und Genehmigungen
 *Abgeleitet aus [CONTRACT_AND_APPROVALS.agc]*

--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,83 @@
+# Apollo-11
+[![NASA][1]][2]
+
+:crossed_flags:
+**Deutsch**,
+[English][EN],
+[Español][ES],
+[Français][FR],
+[Português][PT_BR],
+[正體中文][ZH_TW],
+[简体中文][ZH_CN],
+[한국어][KO_KR],
+[हिंदी][HI_IN]
+
+
+[DE]:README.de.md
+[EN]:README.md
+[ES]:README.es.md
+[FR]:README.fr.md
+[PT_BR]:README.pt_br.md
+[ZH_TW]:README.zh_tw.md
+[ZH_CN]:README.zh_cn.md
+[KO_KR]:README.ko_kr.md
+[HI_IN]:README.hi_in.md
+
+Dieses Repository beinhaltet den originalen Quellcode des Apollo 11
+Navigationscomputers (kurz AGC) für das Kommandomodul (Comanche055)
+und das Mondlandefähre (Luminary099). Digitalisiert wurde der Code
+durch das [Virtual AGC][3] Projekt und das [MIT Museum][4]. Ziel
+dieses Projektes ist es, den originalen Apollo 11 Source Code an einem
+zentralen Ort zu sammeln. Daher sind PRs, die Diskrepanzen zwischen
+den Transkripten in diesem Repository und den originalen Scans des
+Source Codes von [Luminary 099][5] und [Comanche 055][6] beheben, gern
+gesehen.
+
+## Mitmachen
+Bitte lies [CONTRIBUTING.md][7], bevor du einen Pull Request öffnest.
+
+## Kompilieren
+Wenn du den originalen Quellcode gern selbst kompilieren möchtest,
+wirf am besten einen Blick auf das [Virtual AGC][8] Projekt.
+
+## Attribution
+
+&nbsp;         | &nbsp;
+:------------- | :-----
+Copyright      | Gemeingut
+Comanche055    | Teil des Quellcodes für Colossus 2A, den Apollo Navigationscomputer (AGC) des Kommandomoduls (CM) für Apollo 11<br>`Assemble revision 055 of AGC program Comanche by NASA`<br>`2021113-051. 10:28 APR. 1, 1969`
+Luminary099    | Teil des Quellcodes für Luminary 1A, den Apollo Navigationscomputer (AGC) der Mondlandefähre (LM) für Apollo 11<br>`Assemble revision 001 of AGC program LYM99 by NASA`<br>`2021112-061. 16:27 JUL. 14, 1969`
+Assembler      | yaYUL
+Contact        | Ron Burkey <info@sandroid.org>
+Website        | www.ibiblio.org/apollo
+Digitalization | Der vorliegende Quellcode wurde von digitalisierten Bildern einer physischen Kopie des MIT Museums transkribiert oder anderweitig adaptiert. Die Digitalisierung wurde furchgeführt von Paul Fjeld nach Vorbereitung von Deborah Douglas vom MIT Museum. Vielen Dank an beide.
+
+### Vertrag und Genehmigungen
+*Abgeleitet aus [CONTRACT_AND_APPROVALS.agc]*
+
+Dieses AGC Programm soll auch Colossus 2A genannt werden.
+
+Dieses Programm ist für die Benutzung im CM vorgesehen, wie in Report `R577` spezifiziert. Das Programm wurde vorbereitet im Rahmen des DSR Projekts `55-23870`, gesponsort vom Zentrum für bemannte Raumfahrt der National Aeronautics and Space Administration durch Vertrag `NAS 9-4065`, geschlossen mit dem Instrumentation Laboratory des Massachusetts Institute of Technology, Cambridge, Mass.
+
+Eingereicht von       | Position | Datum
+:-------------------- | :------- | :----
+Margaret H. Hamilton  | Leitende Colossus Programmiererin<br>Apollo Steuerung und Navigation | 28. März 1969
+
+Genehmigt von      | Position | Datum
+:----------------- | :------- | :----
+Daniel J. Lickly   | Direktor, Mission Program Development<br>Apollo Steuerungs- und Navigationsprogramm | 28. März 1969
+Fred H. Martin     | Colossus Projektmanager<br>Apollo Steuerungs- und Navigationsprogramm | 28. März 1969
+Norman E. Sears    | Direktor, Mission Development<br>Apollo Steuerungs- und Navigationsprogramm | 28. März 1969
+Richard H. Battin  | Direktor, Mission Development<br>Apollo Steuerungs- und Navigationsprogramm | 28. März 1969
+David G. Hoag      | Direktor<br>Apollo Steuerungs- und Navigationsprogramm | 28. März 1969
+Ralph R. Ragan     | Stellvertretender Direktor<br>Instrumentation Laboratory | 28. März 1969
+
+[CONTRACT_AND_APPROVALS.agc]:https://github.com/chrislgarry/Apollo-11/blob/master/Comanche055/CONTRACT_AND_APPROVALS.agc
+[1]:https://cdn.rawgit.com/aleen42/badges/c9246f74/src/nasa.svg
+[2]:https://www.nasa.gov/mission_pages/apollo/missions/apollo11.html
+[3]:http://www.ibiblio.org/apollo/
+[4]:http://web.mit.edu/museum/
+[5]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
+[6]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
+[7]:https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.md
+[8]:https://github.com/rburkey2005/virtualagc

--- a/README.es.md
+++ b/README.es.md
@@ -2,6 +2,7 @@
 [![NASA][1]][2]
 
 :crossed_flags:
+[Deutsch][DE],
 [English][EN],
 **Español**,
 [Français][FR],
@@ -11,6 +12,7 @@
 [한국어][KO_KR],
 [हिंदी][HI_IN]
 
+[DE]:README.de.md
 [EN]:README.md
 [ES]:README.es.md
 [FR]:README.fr.md

--- a/README.fr.md
+++ b/README.fr.md
@@ -2,6 +2,7 @@
 [![NASA][1]][2]
 
 :crossed_flags:
+[Deutsch][DE],
 [English][EN],
 [Español][ES],
 **Français**,
@@ -12,6 +13,7 @@
 [हिंदी][HI_IN]
 
 
+[DE]:README.de.md
 [EN]:README.md
 [ES]:README.es.md
 [FR]:README.fr.md

--- a/README.hi_in.md
+++ b/README.hi_in.md
@@ -2,6 +2,7 @@
 [![NASA][1]][2]
 
 :crossed_flags:
+[Deutsch][DE],
 [English][EN],
 [Español][ES],
 [Français][FR],
@@ -11,6 +12,7 @@
 [한국어][KO_KR],
 **हिंदी**
 
+[DE]:README.de.md
 [EN]:README.md
 [ES]:README.es.md
 [FR]:README.fr.md

--- a/README.ko_kr.md
+++ b/README.ko_kr.md
@@ -2,6 +2,7 @@
 [![NASA][1]][2]
 
 :crossed_flags:
+[Deutsch][DE],
 [English][EN],
 [Español][ES],
 [Français][FR],
@@ -12,6 +13,7 @@
 [हिंदी][HI_IN]
 
 
+[DE]:README.de.md
 [EN]:README.md
 [ES]:README.es.md
 [FR]:README.fr.md

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![NASA][1]][2]
 
 :crossed_flags:
+[Deutsch][DE],
 **English**,
 [Español][ES],
 [Français][FR],
@@ -12,6 +13,7 @@
 [हिंदी][HI_IN]
 
 
+[DE]:README.de.md
 [EN]:README.md
 [ES]:README.es.md
 [FR]:README.fr.md

--- a/README.pt_br.md
+++ b/README.pt_br.md
@@ -2,6 +2,7 @@
 [![NASA][1]][2]
 
 :crossed_flags:
+[Deutsch][DE],
 [English][EN],
 [Español][ES],
 [Français][FR],
@@ -12,6 +13,7 @@
 [हिंदी][HI_IN]
 
 
+[DE]:README.de.md
 [EN]:README.md
 [ES]:README.es.md
 [FR]:README.fr.md

--- a/README.zh_cn.md
+++ b/README.zh_cn.md
@@ -2,6 +2,7 @@
 [![NASA][1]][2]
 
 :crossed_flags:
+[Deutsch][DE],
 [English][EN],
 [Español][ES],
 [Français][FR],
@@ -12,6 +13,7 @@
 [हिंदी][HI_IN]
 
 
+[DE]:README.de.md
 [EN]:README.md
 [ES]:README.es.md
 [FR]:README.fr.md

--- a/README.zh_tw.md
+++ b/README.zh_tw.md
@@ -2,6 +2,7 @@
 [![NASA][1]][2]
 
 :crossed_flags:
+[Deutsch][DE],
 [English][EN],
 [Español][ES],
 [Français][FR],
@@ -11,6 +12,7 @@
 [한국어][KO_KR],
 [हिंदी][HI_IN]
 
+[DE]:README.de.md
 [EN]:README.md
 [ES]:README.es.md
 [FR]:README.fr.md


### PR DESCRIPTION
I wrote a german version of the readme and included proper links into the other language versions.

All remaining english phrases in the README were left in there intentionally as some of them either have no translation into german or would sound ridiculous (i.e., no one would say that in german). By now we have quite a number of anglicisms in our language. 😅

If there are any issues I am more than happy to fix them!