### PR TITLE
Contributing: Add more text editors with AGC syntax support

### DIFF
--- a/CONTRIBUTING.ar.md
+++ b/CONTRIBUTING.ar.md
@@ -23,9 +23,27 @@
 ## ملحقات مفيدة
 
 يحتوي GitHub على دعم للغة تجميع AGC المضمنة. للاسف، لن يدعمه محرر الكود الخاص بك، ولكن هناك ملحقات توفر دعم للغة AGC من المحررين التاليين:
-- [Atom][5]
-- [Sublime Text 3][4]
-- [Visual Studio Code][3]
+- [Atom][Atom] (supports auto formatting)
+- [CodeBlocks][CodeBlocks]
+- [Eclipse][Eclipse]
+- [Kate][Kate]
+- [ProgrammersNotepad][ProgrammersNotepad]
+- [Sublime Text 3][Sublime Text] (supports auto formatting)
+- [TextPad][TextPad]
+- [Vim][Vim]
+- [Visual Studio Code][VisualStudioCode] (supports auto formatting)
+- [jEdit][jEdit]
+
+[Atom]:https://github.com/Alhadis/language-agc
+[CodeBlocks]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/CodeBlocks
+[Eclipse]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/Eclipse
+[Kate]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/Kate
+[ProgrammersNotepad]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/ProgrammersNotepad
+[Sublime Text]:https://github.com/jimlawton/AGC-Assembly
+[TextPad]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/TextPad
+[Vim]:https://github.com/wsdjeg/vim-assembly
+[VisualStudioCode]:https://github.com/wopian/agc-assembly
+[jEdit]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/jEdit
 
 ## التنسيق
 **ملاحظة:**  سيضمن GitHub والإضافات الثلاثة المذكورة أعلاه أنك تستخدم التنسيق الصحيح تلقائيًا.
@@ -90,9 +108,6 @@ R0820
 [0]:https://github.com/chrislgarry/Apollo-11/pull/new/master
 [1]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [2]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[3]:https://github.com/wopian/agc-assembly
-[4]:https://github.com/jimlawton/AGC-Assembly
-[5]:https://github.com/Alhadis/language-agc
 [6]:https://github.com/wopian/agc-assembly#user-settings
 [7]:https://github.com/chrislgarry/Apollo-11/issues/159
 [8]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/

--- a/CONTRIBUTING.ar.md
+++ b/CONTRIBUTING.ar.md
@@ -23,16 +23,18 @@
 ## ملحقات مفيدة
 
 يحتوي GitHub على دعم للغة تجميع AGC المضمنة. للاسف، لن يدعمه محرر الكود الخاص بك، ولكن هناك ملحقات توفر دعم للغة AGC من المحررين التاليين:
-- [Atom][Atom] (supports auto formatting)
+- [Atom][Atom]†
 - [CodeBlocks][CodeBlocks]
 - [Eclipse][Eclipse]
 - [Kate][Kate]
 - [ProgrammersNotepad][ProgrammersNotepad]
-- [Sublime Text 3][Sublime Text] (supports auto formatting)
+- [Sublime Text 3][Sublime Text]†
 - [TextPad][TextPad]
 - [Vim][Vim]
-- [Visual Studio Code][VisualStudioCode] (supports auto formatting)
+- [Visual Studio Code][VisualStudioCode]†
 - [jEdit][jEdit]
+
+† Supports automatic formatting
 
 [Atom]:https://github.com/Alhadis/language-agc
 [CodeBlocks]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/CodeBlocks

--- a/CONTRIBUTING.ar.md
+++ b/CONTRIBUTING.ar.md
@@ -34,7 +34,7 @@
 - [Visual Studio Code][VisualStudioCode]†
 - [jEdit][jEdit]
 
-† Supports automatic formatting
+† يدعم التنسيق الآلي
 
 [Atom]:https://github.com/Alhadis/language-agc
 [CodeBlocks]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/CodeBlocks

--- a/CONTRIBUTING.ko_kr.md
+++ b/CONTRIBUTING.ko_kr.md
@@ -18,16 +18,18 @@ GitHub은 내장 에디터에서 AGC문법을 지원합니다.
 그러나 불행하게도 대개 사용되는 에디터들은 그렇지 않습니다.
 하지만 확장 기능이 지원되는 에디터들이 있습니다.
 
-- [Atom][Atom] (supports auto formatting)
+- [Atom][Atom]†
 - [CodeBlocks][CodeBlocks]
 - [Eclipse][Eclipse]
 - [Kate][Kate]
 - [ProgrammersNotepad][ProgrammersNotepad]
-- [Sublime Text 3][Sublime Text] (supports auto formatting)
+- [Sublime Text 3][Sublime Text]†
 - [TextPad][TextPad]
 - [Vim][Vim]
-- [Visual Studio Code][VisualStudioCode] (supports auto formatting)
+- [Visual Studio Code][VisualStudioCode]†
 - [jEdit][jEdit]
+
+† Supports automatic formatting
 
 [Atom]:https://github.com/Alhadis/language-agc
 [CodeBlocks]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/CodeBlocks

--- a/CONTRIBUTING.ko_kr.md
+++ b/CONTRIBUTING.ko_kr.md
@@ -18,9 +18,27 @@ GitHub은 내장 에디터에서 AGC문법을 지원합니다.
 그러나 불행하게도 대개 사용되는 에디터들은 그렇지 않습니다.
 하지만 확장 기능이 지원되는 에디터들이 있습니다.
 
-- [Atom][5]
-- [Sublime Text 3][4]
-- [Visual Studio Code][3]
+- [Atom][Atom] (supports auto formatting)
+- [CodeBlocks][CodeBlocks]
+- [Eclipse][Eclipse]
+- [Kate][Kate]
+- [ProgrammersNotepad][ProgrammersNotepad]
+- [Sublime Text 3][Sublime Text] (supports auto formatting)
+- [TextPad][TextPad]
+- [Vim][Vim]
+- [Visual Studio Code][VisualStudioCode] (supports auto formatting)
+- [jEdit][jEdit]
+
+[Atom]:https://github.com/Alhadis/language-agc
+[CodeBlocks]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/CodeBlocks
+[Eclipse]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/Eclipse
+[Kate]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/Kate
+[ProgrammersNotepad]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/ProgrammersNotepad
+[Sublime Text]:https://github.com/jimlawton/AGC-Assembly
+[TextPad]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/TextPad
+[Vim]:https://github.com/wsdjeg/vim-assembly
+[VisualStudioCode]:https://github.com/wopian/agc-assembly
+[jEdit]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/jEdit
 
 ## 포매팅
 **참고:** Github 내장 에디터와 위의 세 확장기능들은 이 문단에서 정의하는 포매팅을 자동으로 수행해줍니다.
@@ -64,8 +82,5 @@ R0820
 [0]:https://github.com/chrislgarry/Apollo-11/pull/new/master
 [1]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [2]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[3]:https://github.com/wopian/agc-assembly
-[4]:https://github.com/jimlawton/AGC-Assembly
-[5]:https://github.com/Alhadis/language-agc
 [6]:https://github.com/wopian/agc-assembly#user-settings
 [7]:https://github.com/chrislgarry/Apollo-11/issues/159

--- a/CONTRIBUTING.ko_kr.md
+++ b/CONTRIBUTING.ko_kr.md
@@ -29,7 +29,7 @@ GitHub은 내장 에디터에서 AGC문법을 지원합니다.
 - [Visual Studio Code][VisualStudioCode]†
 - [jEdit][jEdit]
 
-† Supports automatic formatting
+† 자동 포매팅 지원
 
 [Atom]:https://github.com/Alhadis/language-agc
 [CodeBlocks]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/CodeBlocks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,16 +21,18 @@ The source code in this repository was digitized manually from paper printouts, 
 ## Useful Extensions
 
 GitHub has syntax support for the AGC assembly language built-in. Unfortunately your code editor will not, however there are AGC language extensions that provides syntax highlighting for the following editors:
-- [Atom][Atom] (supports auto formatting)
+- [Atom][Atom]†
 - [CodeBlocks][CodeBlocks]
 - [Eclipse][Eclipse]
 - [Kate][Kate]
 - [ProgrammersNotepad][ProgrammersNotepad]
-- [Sublime Text 3][Sublime Text] (supports auto formatting)
+- [Sublime Text 3][Sublime Text]†
 - [TextPad][TextPad]
 - [Vim][Vim]
-- [Visual Studio Code][VisualStudioCode] (supports auto formatting)
+- [Visual Studio Code][VisualStudioCode]†
 - [jEdit][jEdit]
+
+† Supports automatic formatting
 
 [Atom]:https://github.com/Alhadis/language-agc
 [CodeBlocks]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/CodeBlocks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,17 +20,31 @@ The source code in this repository was digitized manually from paper printouts, 
 
 ## Useful Extensions
 
-GitHub has syntax support for the AGC assembly language built-in.
-Unfortunately your code editor will not, however there are
-AGC language extensions that provides syntax highlighting for the
-following editors:
-- [Atom][5]
-- [Sublime Text 3][4]
-- [Visual Studio Code][3]
+GitHub has syntax support for the AGC assembly language built-in. Unfortunately your code editor will not, however there are AGC language extensions that provides syntax highlighting for the following editors:
+- [Atom][Atom] (supports auto formatting)
+- [CodeBlocks][CodeBlocks]
+- [Eclipse][Eclipse]
+- [Kate][Kate]
+- [ProgrammersNotepad][ProgrammersNotepad]
+- [Sublime Text 3][Sublime Text] (supports auto formatting)
+- [TextPad][TextPad]
+- [Vim][Vim]
+- [Visual Studio Code][VisualStudioCode] (supports auto formatting)
+- [jEdit][jEdit]
+
+[Atom]:https://github.com/Alhadis/language-agc
+[CodeBlocks]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/CodeBlocks
+[Eclipse]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/Eclipse
+[Kate]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/Kate
+[ProgrammersNotepad]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/ProgrammersNotepad
+[Sublime Text]:https://github.com/jimlawton/AGC-Assembly
+[TextPad]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/TextPad
+[Vim]:https://github.com/wsdjeg/vim-assembly
+[VisualStudioCode]:https://github.com/wopian/agc-assembly
+[jEdit]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/jEdit
 
 ## Formatting
-**Note:** GitHub and the 3 extensions listed above will ensure
-you're using the correct formatting automatically.
+**Note:** GitHub and extensions marked above will ensure you're using the correct formatting automatically.
 
 - Use tab indentation
 - Use tab width of 8
@@ -41,20 +55,14 @@ Any discrepancies between the scans and the source code in this repository, incl
 
 ### Comments
 - Comments in the transcribed code should match the scans exactly
-  - This could involve creating a deliberate typo or removing/adding
-  an entire comment.
+  - This could involve creating a deliberate typo or removing/adding an entire comment.
 
 ### Line breaks
 - Line breaks *with* `R0000` in column 1 should match the scans exactly.
-- Line breaks *with**__out__* `R0000` in column 1 should contain only 1
-or 2 blank lines in a row.
-  - If there are more than 2 blank lines breaks, strip the extra
-  line breaks.
+- Line breaks *with**__out__* `R0000` in column 1 should contain only 1 or 2 blank lines in a row.
+  - If there are more than 2 blank lines breaks, strip the extra line breaks.
     - Lines with `R0000` in column 1 do not count towards this.
-  - In the source images, these were created by an unprinted digit
-  in column 8. A 2 there forced a double space (single blank line)
-  and a 3 forced a triple space (double blank line). Values 4-8 were
-  defined but never used. Read more about it in [#159][7]
+  - In the source images, these were created by an unprinted digit in column 8. A 2 there forced a double space (single blank line) and a 3 forced a triple space (double blank line). Values 4-8 were defined but never used. Read more about it in [#159][7]
 
 For example the following:
 ```plain
@@ -98,9 +106,6 @@ Before you make a PR, please make sure your changes are consistent with the scan
 [0]:https://github.com/chrislgarry/Apollo-11/pull/new/master
 [1]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [2]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[3]:https://github.com/wopian/agc-assembly
-[4]:https://github.com/jimlawton/AGC-Assembly
-[5]:https://github.com/Alhadis/language-agc
 [6]:https://github.com/wopian/agc-assembly#user-settings
 [7]:https://github.com/chrislgarry/Apollo-11/issues/159
 [8]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/

--- a/CONTRIBUTING.pt_br.md
+++ b/CONTRIBUTING.pt_br.md
@@ -33,7 +33,7 @@ Infelizmente, seu editor de texto não o terá. Portanto, existem extensões par
 - [Visual Studio Code][VisualStudioCode]†
 - [jEdit][jEdit]
 
-† Supports automatic formatting
+† Suporta formatação automática
 
 [Atom]:https://github.com/Alhadis/language-agc
 [CodeBlocks]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/CodeBlocks

--- a/CONTRIBUTING.pt_br.md
+++ b/CONTRIBUTING.pt_br.md
@@ -22,9 +22,27 @@ O código-fonte neste repositório foi digitado manualmente a partir de impress�
 
 Github possui suporte de sintaxe nativo para a linguagem assembly AGC.
 Infelizmente, seu editor de texto não o terá. Portanto, existem extensões para a linguagem AGC que providenciam destaque de sintaxe para os seguintes editores:
-- [Atom][5]
-- [Sublime Text 3][4]
-- [Visual Studio Code][3]
+- [Atom][Atom] (supports auto formatting)
+- [CodeBlocks][CodeBlocks]
+- [Eclipse][Eclipse]
+- [Kate][Kate]
+- [ProgrammersNotepad][ProgrammersNotepad]
+- [Sublime Text 3][Sublime Text] (supports auto formatting)
+- [TextPad][TextPad]
+- [Vim][Vim]
+- [Visual Studio Code][VisualStudioCode] (supports auto formatting)
+- [jEdit][jEdit]
+
+[Atom]:https://github.com/Alhadis/language-agc
+[CodeBlocks]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/CodeBlocks
+[Eclipse]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/Eclipse
+[Kate]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/Kate
+[ProgrammersNotepad]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/ProgrammersNotepad
+[Sublime Text]:https://github.com/jimlawton/AGC-Assembly
+[TextPad]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/TextPad
+[Vim]:https://github.com/wsdjeg/vim-assembly
+[VisualStudioCode]:https://github.com/wopian/agc-assembly
+[jEdit]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/jEdit
 
 ## Formatando
 **Nota:** Github e as três extensões listadas acima garantirão que você estará usando a formatação correta automaticamente.
@@ -89,9 +107,6 @@ Antes de realizar um PR, por favor, certifique-se que suas mudanças estejam con
 [0]:https://github.com/chrislgarry/Apollo-11/pull/new/master
 [1]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [2]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[3]:https://github.com/wopian/agc-assembly
-[4]:https://github.com/jimlawton/AGC-Assembly
-[5]:https://github.com/Alhadis/language-agc
 [6]:https://github.com/wopian/agc-assembly#user-settings
 [7]:https://github.com/chrislgarry/Apollo-11/issues/159
 [8]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/

--- a/CONTRIBUTING.pt_br.md
+++ b/CONTRIBUTING.pt_br.md
@@ -22,16 +22,18 @@ O código-fonte neste repositório foi digitado manualmente a partir de impress�
 
 Github possui suporte de sintaxe nativo para a linguagem assembly AGC.
 Infelizmente, seu editor de texto não o terá. Portanto, existem extensões para a linguagem AGC que providenciam destaque de sintaxe para os seguintes editores:
-- [Atom][Atom] (supports auto formatting)
+- [Atom][Atom]†
 - [CodeBlocks][CodeBlocks]
 - [Eclipse][Eclipse]
 - [Kate][Kate]
 - [ProgrammersNotepad][ProgrammersNotepad]
-- [Sublime Text 3][Sublime Text] (supports auto formatting)
+- [Sublime Text 3][Sublime Text]†
 - [TextPad][TextPad]
 - [Vim][Vim]
-- [Visual Studio Code][VisualStudioCode] (supports auto formatting)
+- [Visual Studio Code][VisualStudioCode]†
 - [jEdit][jEdit]
+
+† Supports automatic formatting
 
 [Atom]:https://github.com/Alhadis/language-agc
 [CodeBlocks]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/CodeBlocks

--- a/CONTRIBUTING.tr.md
+++ b/CONTRIBUTING.tr.md
@@ -20,16 +20,18 @@ Bu repodaki kaynak kodu kağıt çıktılarından elle dijitalleştirilmiştir. 
 ## Yararlı Eklentiler
 
 Github, AGC assembly dili için sentaks desteği sağlıyor ama sizin kodu düzenlemek için kullandığınız editör sağlamayacaktır. Aşağıdaki editörler AGC dili sentaks vurgulaması için eklentiler sunmaktadır:
-- [Atom][Atom] (supports auto formatting)
+- [Atom][Atom]†
 - [CodeBlocks][CodeBlocks]
 - [Eclipse][Eclipse]
 - [Kate][Kate]
 - [ProgrammersNotepad][ProgrammersNotepad]
-- [Sublime Text 3][Sublime Text] (supports auto formatting)
+- [Sublime Text 3][Sublime Text]†
 - [TextPad][TextPad]
 - [Vim][Vim]
-- [Visual Studio Code][VisualStudioCode] (supports auto formatting)
+- [Visual Studio Code][VisualStudioCode]†
 - [jEdit][jEdit]
+
+† Otomatik biçimlendirmeyi destekler
 
 [Atom]:https://github.com/Alhadis/language-agc
 [CodeBlocks]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/CodeBlocks

--- a/CONTRIBUTING.tr.md
+++ b/CONTRIBUTING.tr.md
@@ -20,9 +20,27 @@ Bu repodaki kaynak kodu kağıt çıktılarından elle dijitalleştirilmiştir. 
 ## Yararlı Eklentiler
 
 Github, AGC assembly dili için sentaks desteği sağlıyor ama sizin kodu düzenlemek için kullandığınız editör sağlamayacaktır. Aşağıdaki editörler AGC dili sentaks vurgulaması için eklentiler sunmaktadır:
-- [Atom][5]
-- [Sublime Text 3][4]
-- [Visual Studio Code][3]
+- [Atom][Atom] (supports auto formatting)
+- [CodeBlocks][CodeBlocks]
+- [Eclipse][Eclipse]
+- [Kate][Kate]
+- [ProgrammersNotepad][ProgrammersNotepad]
+- [Sublime Text 3][Sublime Text] (supports auto formatting)
+- [TextPad][TextPad]
+- [Vim][Vim]
+- [Visual Studio Code][VisualStudioCode] (supports auto formatting)
+- [jEdit][jEdit]
+
+[Atom]:https://github.com/Alhadis/language-agc
+[CodeBlocks]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/CodeBlocks
+[Eclipse]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/Eclipse
+[Kate]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/Kate
+[ProgrammersNotepad]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/ProgrammersNotepad
+[Sublime Text]:https://github.com/jimlawton/AGC-Assembly
+[TextPad]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/TextPad
+[Vim]:https://github.com/wsdjeg/vim-assembly
+[VisualStudioCode]:https://github.com/wopian/agc-assembly
+[jEdit]:https://github.com/virtualagc/virtualagc/tree/master/Contributed/SyntaxHighlight/jEdit
 
 ## Biçimlendirme
 **Not:** GitHub ve yukarıdaki 3 eklenti otomatik olarak doğru biçimlendirmeyi kullanmanızı sağlayacaktır.
@@ -87,9 +105,6 @@ PR yapmadan önce lütfen yaptığınız değişikliklerin çıktılar ile tutar
 [0]:https://github.com/chrislgarry/Apollo-11/pull/new/master
 [1]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [2]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[3]:https://github.com/wopian/agc-assembly
-[4]:https://github.com/jimlawton/AGC-Assembly
-[5]:https://github.com/Alhadis/language-agc
 [6]:https://github.com/wopian/agc-assembly#user-settings
 [7]:https://github.com/chrislgarry/Apollo-11/issues/159
 [8]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/


### PR DESCRIPTION
Added some more syntax-only extensions for other popular code editors.

- [x] Arabic
- [x] English
- [x] Korean
- [x] Portuguese
- [x] Turkish 