### PR TITLE
Add Bangla (#534) and Burmese (#415) README and use correct commas in Persian README

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -4,29 +4,31 @@
 [![NASA][1]][2]
 
 :crossed_flags:
-[Bahasa Indonesia][ID],
-[বাংলা][BD_BN],
-[Català][CA],
-[Deutsch][DE],
-[English][EN],
-[Español][ES],
-[Français][FR],
-[Italiano][IT],
-[Polski][PL],
-[Português][PT_BR],
-[Română][RO],
-[Tiếng Việt][VI],
-[Türkçe][TR],
-[Русский][RU],
-**العربية**,
-[فارسی][FA],
-[हिंदी][HI_IN],
-[日本][JA],
-[正體中文][ZH_TW],
-[简体中文][ZH_CN],
-[မြန်မာ][MM]
+[Bahasa Indonesia][ID]،
+[Català][CA]،
+[Deutsch][DE]،
+[English][EN]،
+[Español][ES]،
+[Français][FR]،
+[Italiano][IT]،
+[Polski][PL]،
+[Português][PT_BR]،
+[Română][RO]،
+[Tiếng Việt][VI]،
+[Türkçe][TR]،
+[Русский][RU]،
+**العربية**،
+[فارسی][FA]،
+[हिंदी][HI_IN]،
+[বাংলা][BD_BN]،
+[မြန်မာ][MM]،
+[日本][JA]،
+[正體中文][ZH_TW]،
+[简体中文][ZH_CN]،
+[한국어][KO_KR]
 
 [AR]:README.ar.md
+[BD_BN]:README.bd_bn.md
 [CA]:README.ca.md
 [DE]:README.de.md
 [EN]:README.md
@@ -38,6 +40,7 @@
 [IT]:README.it.md
 [JA]:README.ja.md
 [KO_KR]:README.ko_kr.md
+[MM]:README.mm.md
 [PL]:README.pl.md
 [PT_BR]:README.pt_br.md
 [RO]:README.ro.md

--- a/README.ar.md
+++ b/README.ar.md
@@ -5,6 +5,7 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
+[বাংলা][BD_BN],
 [Català][CA],
 [Deutsch][DE],
 [English][EN],

--- a/README.ar.md
+++ b/README.ar.md
@@ -24,7 +24,7 @@
 [日本][JA],
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
-[한국어][KO_KR]
+[မြန်မာ][MM]
 
 [AR]:README.ar.md
 [CA]:README.ca.md

--- a/README.bd_bn.md
+++ b/README.bd_bn.md
@@ -1,40 +1,52 @@
-# অ্যাপোলো ১১ 
+# অ্যাপোলো ১১
 [![NASA][1]][2]
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
-**বাংলা**,
 [Català][CA],
 [Deutsch][DE],
 [English][EN],
 [Español][ES],
 [Français][FR],
 [Italiano][IT],
+[Polski][PL],
 [Português][PT_BR],
+[Română][RO],
+[Tiếng Việt][VI],
+[Türkçe][TR],
 [Русский][RU],
 [العربية][AR],
+[فارسی][FA],
 [हिंदी][HI_IN],
+**বাংলা**,
+[မြန်မာ][MM],
+[日本][JA],
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
-[한국어][KO_KR],
-[日本][JA]
+[한국어][KO_KR]
 
 [AR]:README.ar.md
 [BD_BN]:README.bd_bn.md
-[ID]:README.id.md
 [CA]:README.ca.md
 [DE]:README.de.md
 [EN]:README.md
 [ES]:README.es.md
-[IT]:README.it.md
+[FA]:README.fa.md
 [FR]:README.fr.md
-[JA]:README.ja.md
-[PT_BR]:README.pt_br.md
-[ZH_TW]:README.zh_tw.md
-[ZH_CN]:README.zh_cn.md
-[KO_KR]:README.ko_kr.md
 [HI_IN]:README.hi_in.md
+[ID]:README.id.md
+[IT]:README.it.md
+[JA]:README.ja.md
+[KO_KR]:README.ko_kr.md
+[MM]:README.mm.md
+[PL]:README.pl.md
+[PT_BR]:README.pt_br.md
+[RO]:README.ro.md
 [RU]:README.ru.md
+[TR]:README.tr.md
+[VI]:README.vi.md
+[ZH_CN]:README.zh_cn.md
+[ZH_TW]:README.zh_tw.md
 
 
 অ্যাপোলো ১১ গাইডেন্স কম্পিউটারের মূল ম্যানুয়াল (AGC), অ্যাপোলো ১১ কমান্ড মডিউল (Comanche055) এবং লুনার মডিউল (Luminary099)। এটি [Virtual AGC][3] এবং [MIT Museum][4] সদস্যদের দ্বারা সূচিত করা হয়েছে। আমাদের মূল লক্ষ্য অ্যাপোলো ১১ এর মূল কোডটি সংকলন করা। আপনি যদি এই বিরোধের প্রতিলিপি এবং [Luminary 099][5] এবং [Comanche 055][6] এর মধ্যে কোনও বৈষম্য উন্মোচন করেছেন, সেক্ষেত্রে আপনার সহযোগিতা PR হিসাবে প্রশংসিত হবে।
@@ -49,7 +61,7 @@
 
 &nbsp;         | &nbsp;
 :------------- | :-----
-কপিরাইট      | পাবলিক ডোমেইন 
+কপিরাইট      | পাবলিক ডোমেইন
 Comanche055    | Colossus 2A, কমান্ড মডিউলটির (CM) উত্স কোডের একটি অংশ, অ্যাপোলো ১১ গাইডেন্স কম্পিউটার (AGC)<br>`নাসা 055 দ্বারা AGC প্রোগ্রাম কোমঞ্চের একীভূত সংশোধনী`<br>`2021113-051. 10:28 APR. 1, 1969`
 Luminary099    | লুমিনারি ১ এ, অ্যাপোলো ১১-এর চন্দ্র অংশ (LM) জন্য ফ্লোটেশন ডিভাইস (AGC) কোডের অংশ `নাসার দ্বারা এজিসি (AGC)প্রোগ্রাম LYM99 এর একীভূত সংশোধনী ০০১`<br>`2021112-061. 16:27 JUL. 14, 1969`
 অ্যাসেম্বলার      | yaYUL

--- a/README.bd_bn.md
+++ b/README.bd_bn.md
@@ -1,0 +1,88 @@
+# অ্যাপোলো ১১ 
+[![NASA][1]][2]
+
+:crossed_flags:
+[Bahasa Indonesia][ID],
+**বাংলা**,
+[Català][CA],
+[Deutsch][DE],
+[English][EN],
+[Español][ES],
+[Français][FR],
+[Italiano][IT],
+[Português][PT_BR],
+[Русский][RU],
+[العربية][AR],
+[हिंदी][HI_IN],
+[正體中文][ZH_TW],
+[简体中文][ZH_CN],
+[한국어][KO_KR],
+[日本][JA]
+
+[AR]:README.ar.md
+[BD_BN]:README.bd_bn.md
+[ID]:README.id.md
+[CA]:README.ca.md
+[DE]:README.de.md
+[EN]:README.md
+[ES]:README.es.md
+[IT]:README.it.md
+[FR]:README.fr.md
+[JA]:README.ja.md
+[PT_BR]:README.pt_br.md
+[ZH_TW]:README.zh_tw.md
+[ZH_CN]:README.zh_cn.md
+[KO_KR]:README.ko_kr.md
+[HI_IN]:README.hi_in.md
+[RU]:README.ru.md
+
+
+অ্যাপোলো ১১ গাইডেন্স কম্পিউটারের মূল ম্যানুয়াল (AGC), অ্যাপোলো ১১ কমান্ড মডিউল (Comanche055) এবং লুনার মডিউল (Luminary099)। এটি [Virtual AGC][3] এবং [MIT Museum][4] সদস্যদের দ্বারা সূচিত করা হয়েছে। আমাদের মূল লক্ষ্য অ্যাপোলো ১১ এর মূল কোডটি সংকলন করা। আপনি যদি এই বিরোধের প্রতিলিপি এবং [Luminary 099][5] এবং [Comanche 055][6] এর মধ্যে কোনও বৈষম্য উন্মোচন করেছেন, সেক্ষেত্রে আপনার সহযোগিতা PR হিসাবে প্রশংসিত হবে।
+
+## অবদান
+একটি পুল রিকুয়েস্ট খোলার আগে দয়া করে পড়ুন [CONTRIBUTING.md][7]।
+
+## সংগ্রহ
+যদি আপনি এই নিয়মগুলি পরিচালনা করেন তবে তা [Virtual AGC][8] দেখুন।
+
+## আরোপণ
+
+&nbsp;         | &nbsp;
+:------------- | :-----
+কপিরাইট      | পাবলিক ডোমেইন 
+Comanche055    | Colossus 2A, কমান্ড মডিউলটির (CM) উত্স কোডের একটি অংশ, অ্যাপোলো ১১ গাইডেন্স কম্পিউটার (AGC)<br>`নাসা 055 দ্বারা AGC প্রোগ্রাম কোমঞ্চের একীভূত সংশোধনী`<br>`2021113-051. 10:28 APR. 1, 1969`
+Luminary099    | লুমিনারি ১ এ, অ্যাপোলো ১১-এর চন্দ্র অংশ (LM) জন্য ফ্লোটেশন ডিভাইস (AGC) কোডের অংশ `নাসার দ্বারা এজিসি (AGC)প্রোগ্রাম LYM99 এর একীভূত সংশোধনী ০০১`<br>`2021112-061. 16:27 JUL. 14, 1969`
+অ্যাসেম্বলার      | yaYUL
+যোগাযোগ        | Ron Burkey <info@sandroid.org>
+ওয়েবসাইট        | www.ibiblio.org/apollo
+ডিজিটালাইজেশন  | এই উত্স কোডটি MIT Museum থেকে একটি হার্ডকপির ডিজিটাইজড চিত্র থেকে অনুলিপি করা হয়েছে বা অন্যথায় রূপান্তরিত হয়েছে। ডিজিটালাইজেশনটি Paul Fjeld সঞ্চালনা করেছিলেন এবং যাদুঘরের Deborah Douglas দ্বারা ব্যবস্থা করেছিলেন। উভয়কে অনেক ধন্যবাদ।
+
+### চুক্তি এবং গ্রহণযোগ্যতা
+*থেকে প্রাপ্ত [CONTRACT_AND_APPROVALS.agc]*
+
+এই AGC প্রোগ্রামটিকে Colossus 2A এ হিসাবেও উল্লেখ করা হবে।
+
+এই প্রোগ্রামটি CM প্রতিবেদনে নির্দিষ্ট হিসাবে ব্যবহারের জন্য উদ্দিষ্ট `R-577`. এই প্রোগ্রামটি DSR প্রকল্পের আওতায় প্রস্তুত করা হয়েছিল `55-23870`, এই চুক্তির মাধ্যমে দ্য ন্যাশনাল অ্যারোনটিকস অ্যান্ড স্পেস অ্যাডমিনিস্ট্রেশনের ম্যানড স্পেসক্র্যাফট সেন্টার স্পনসর করে `NAS 9-4065` যন্ত্রানুষঙ্গের ল্যাবরেটরি সহ, Massachusetts Institute of Technology, Cambridge, Mass.
+
+জমাদানকারী          | ভূমিকা | তারিখ
+:-------------------- | :--- | :---
+Margaret H. Hamilton  | কলসাস(Colossus) প্রোগ্রামিং লিডার<br>অ্যাপোলো গাইডেন্স এবং নেভিগেশন | ২৮ মার্চ ১৯৬৯
+
+দ্বারা অনুমোদিত       | ভূমিকা | তারিখ
+:----------------- | :--- | :---
+Daniel J. Lickly   | পরিচালক, মিশন প্রোগ্রাম উন্নয়ন<br>অ্যাপোলো গাইডেন্স এবং নেভিগেশন প্রোগ্রাম | ২৮ মার্চ ১৯৬৯
+Fred H. Martin     | কলসাস প্রজেক্ট ম্যানেজার<br>অ্যাপোলো গাইডেন্স এবং নেভিগেশন প্রোগ্রাম | ২৮ মার্চ ১৯৬৯
+Norman E. Sears    | পরিচালক, মিশন উন্নয়ন<br>অ্যাপোলো গাইডেন্স এবং নেভিগেশন প্রোগ্রাম | ২৮ মার্চ ১৯৬৯
+Richard H. Battin  | পরিচালক, মিশন উন্নয়ন<br>অ্যাপোলো গাইডেন্স এবং নেভিগেশন প্রোগ্রাম | ২৮ মার্চ ১৯৬৯
+David G. Hoag      | পরিচালক<br>অ্যাপোলো গাইডেন্স এবং নেভিগেশন প্রোগ্রাম | ২৮ মার্চ ১৯৬৯
+Ralph R. Ragan     | সহকারী পরিচালক<br>ইনস্ট্রুমেন্টেশন ল্যাবরেটরি | ২৮ মার্চ ১৯৬৯
+
+[CONTRACT_AND_APPROVALS.agc]:https://github.com/chrislgarry/Apollo-11/blob/master/Comanche055/CONTRACT_AND_APPROVALS.agc
+[1]:https://rawcdn.githack.com/aleen42/badges/c9246f74/src/nasa.svg
+[2]:https://www.nasa.gov/mission_pages/apollo/missions/apollo11.html
+[3]:http://www.ibiblio.org/apollo/
+[4]:http://web.mit.edu/museum/
+[5]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
+[6]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
+[7]:https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.md
+[8]:https://github.com/rburkey2005/virtualagc

--- a/README.ca.md
+++ b/README.ca.md
@@ -22,7 +22,7 @@
 [日本][JA],
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
-[한국어][KO_KR]
+[မြန်မာ][MM]
 
 [AR]:README.ar.md
 [CA]:README.ca.md

--- a/README.ca.md
+++ b/README.ca.md
@@ -3,6 +3,7 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
+[বাংলা][BD_BN],
 **Català**,
 [Deutsch][DE],
 [English][EN],

--- a/README.ca.md
+++ b/README.ca.md
@@ -3,7 +3,6 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
-[বাংলা][BD_BN],
 **Català**,
 [Deutsch][DE],
 [English][EN],
@@ -19,12 +18,15 @@
 [العربية][AR],
 [فارسی][FA],
 [हिंदी][HI_IN],
+[বাংলা][BD_BN],
+[မြန်မာ][MM],
 [日本][JA],
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
-[မြန်မာ][MM]
+[한국어][KO_KR]
 
 [AR]:README.ar.md
+[BD_BN]:README.bd_bn.md
 [CA]:README.ca.md
 [DE]:README.de.md
 [EN]:README.md
@@ -36,6 +38,7 @@
 [IT]:README.it.md
 [JA]:README.ja.md
 [KO_KR]:README.ko_kr.md
+[MM]:README.mm.md
 [PL]:README.pl.md
 [PT_BR]:README.pt_br.md
 [RO]:README.ro.md

--- a/README.de.md
+++ b/README.de.md
@@ -23,6 +23,7 @@
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
 [한국어][KO_KR]
+[မြန်မာ][MM]
 
 [AR]:README.ar.md
 [CA]:README.ca.md

--- a/README.de.md
+++ b/README.de.md
@@ -3,6 +3,7 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
+[বাংলা][BD_BN],
 [Català][CA],
 **Deutsch**,
 [English][EN],

--- a/README.de.md
+++ b/README.de.md
@@ -3,7 +3,6 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
-[বাংলা][BD_BN],
 [Català][CA],
 **Deutsch**,
 [English][EN],
@@ -19,13 +18,15 @@
 [العربية][AR],
 [فارسی][FA],
 [हिंदी][HI_IN],
+[বাংলা][BD_BN],
+[မြန်မာ][MM],
 [日本][JA],
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
 [한국어][KO_KR]
-[မြန်မာ][MM]
 
 [AR]:README.ar.md
+[BD_BN]:README.bd_bn.md
 [CA]:README.ca.md
 [DE]:README.de.md
 [EN]:README.md
@@ -37,6 +38,7 @@
 [IT]:README.it.md
 [JA]:README.ja.md
 [KO_KR]:README.ko_kr.md
+[MM]:README.mm.md
 [PL]:README.pl.md
 [PT_BR]:README.pt_br.md
 [RO]:README.ro.md

--- a/README.es.md
+++ b/README.es.md
@@ -22,7 +22,7 @@
 [日本][JA],
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
-[한국어][KO_KR]
+[မြန်မာ][MM]
 
 [AR]:README.ar.md
 [CA]:README.ca.md

--- a/README.es.md
+++ b/README.es.md
@@ -3,6 +3,7 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
+[বাংলা][BD_BN],
 [Català][CA],
 [Deutsch][DE],
 [English][EN],

--- a/README.es.md
+++ b/README.es.md
@@ -3,7 +3,6 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
-[বাংলা][BD_BN],
 [Català][CA],
 [Deutsch][DE],
 [English][EN],
@@ -19,12 +18,15 @@
 [العربية][AR],
 [فارسی][FA],
 [हिंदी][HI_IN],
+[বাংলা][BD_BN],
+[မြန်မာ][MM],
 [日本][JA],
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
-[မြန်မာ][MM]
+[한국어][KO_KR]
 
 [AR]:README.ar.md
+[BD_BN]:README.bd_bn.md
 [CA]:README.ca.md
 [DE]:README.de.md
 [EN]:README.md
@@ -36,6 +38,7 @@
 [IT]:README.it.md
 [JA]:README.ja.md
 [KO_KR]:README.ko_kr.md
+[MM]:README.mm.md
 [PL]:README.pl.md
 [PT_BR]:README.pt_br.md
 [RO]:README.ro.md

--- a/README.fa.md
+++ b/README.fa.md
@@ -5,28 +5,31 @@
 [![NASA][1]][2]
 
 :crossed_flags:
-[Bahasa Indonesia][ID],
-[Català][CA],
-[Deutsch][DE],
-[English][EN],
-[Español][ES],
-[Français][FR],
-[Italiano][IT],
-[Polski][PL],
-[Português][PT_BR],
-[Română][RO],
-[Tiếng Việt][VI],
-[Türkçe][TR],
-[Русский][RU],
-[العربية][AR],
-**فارسی**,
-[हिंदी][HI_IN],
-[日本][JA],
-[正體中文][ZH_TW],
-[简体中文][ZH_CN],
+[Bahasa Indonesia][ID]،
+[Català][CA]،
+[Deutsch][DE]،
+[English][EN]،
+[Español][ES]،
+[Français][FR]،
+[Italiano][IT]،
+[Polski][PL]،
+[Português][PT_BR]،
+[Română][RO]،
+[Tiếng Việt][VI]،
+[Türkçe][TR]،
+[Русский][RU]،
+[العربية][AR]،
+**فارسی**،
+[हिंदी][HI_IN]،
+[বাংলা][BD_BN]،
+[မြန်မာ][MM]،
+[日本][JA]،
+[正體中文][ZH_TW]،
+[简体中文][ZH_CN]،
 [한국어][KO_KR]
 
 [AR]:README.ar.md
+[BD_BN]:README.bd_bn.md
 [CA]:README.ca.md
 [DE]:README.de.md
 [EN]:README.md
@@ -38,6 +41,7 @@
 [IT]:README.it.md
 [JA]:README.ja.md
 [KO_KR]:README.ko_kr.md
+[MM]:README.mm.md
 [PL]:README.pl.md
 [PT_BR]:README.pt_br.md
 [RO]:README.ro.md

--- a/README.fr.md
+++ b/README.fr.md
@@ -23,6 +23,7 @@
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
 [한국어][KO_KR]
+[မြန်မာ][MM]
 
 [AR]:README.ar.md
 [CA]:README.ca.md

--- a/README.fr.md
+++ b/README.fr.md
@@ -3,7 +3,6 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
-[বাংলা][BD_BN],
 [Català][CA],
 [Deutsch][DE],
 [English][EN],
@@ -19,13 +18,15 @@
 [العربية][AR],
 [فارسی][FA],
 [हिंदी][HI_IN],
+[বাংলা][BD_BN],
+[မြန်မာ][MM],
 [日本][JA],
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
 [한국어][KO_KR]
-[မြန်မာ][MM]
 
 [AR]:README.ar.md
+[BD_BN]:README.bd_bn.md
 [CA]:README.ca.md
 [DE]:README.de.md
 [EN]:README.md
@@ -37,6 +38,7 @@
 [IT]:README.it.md
 [JA]:README.ja.md
 [KO_KR]:README.ko_kr.md
+[MM]:README.mm.md
 [PL]:README.pl.md
 [PT_BR]:README.pt_br.md
 [RO]:README.ro.md

--- a/README.fr.md
+++ b/README.fr.md
@@ -3,6 +3,7 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
+[বাংলা][BD_BN],
 [Català][CA],
 [Deutsch][DE],
 [English][EN],

--- a/README.hi_in.md
+++ b/README.hi_in.md
@@ -23,6 +23,7 @@
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
 [한국어][KO_KR]
+[မြန်မာ][MM]
 
 [AR]:README.ar.md
 [CA]:README.ca.md

--- a/README.hi_in.md
+++ b/README.hi_in.md
@@ -3,7 +3,6 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
-[বাংলা][BD_BN],
 [Català][CA],
 [Deutsch][DE],
 [English][EN],
@@ -19,13 +18,15 @@
 [العربية][AR],
 [فارسی][FA],
 **हिंदी**,
+[বাংলা][BD_BN],
+[မြန်မာ][MM],
 [日本][JA],
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
 [한국어][KO_KR]
-[မြန်မာ][MM]
 
 [AR]:README.ar.md
+[BD_BN]:README.bd_bn.md
 [CA]:README.ca.md
 [DE]:README.de.md
 [EN]:README.md
@@ -37,6 +38,7 @@
 [IT]:README.it.md
 [JA]:README.ja.md
 [KO_KR]:README.ko_kr.md
+[MM]:README.mm.md
 [PL]:README.pl.md
 [PT_BR]:README.pt_br.md
 [RO]:README.ro.md

--- a/README.hi_in.md
+++ b/README.hi_in.md
@@ -3,6 +3,7 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
+[বাংলা][BD_BN],
 [Català][CA],
 [Deutsch][DE],
 [English][EN],

--- a/README.id.md
+++ b/README.id.md
@@ -23,6 +23,7 @@
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
 [한국어][KO_KR]
+[မြန်မာ][MM]
 
 [AR]:README.ar.md
 [CA]:README.ca.md

--- a/README.id.md
+++ b/README.id.md
@@ -3,7 +3,6 @@
 
 :crossed_flags:
 **Bahasa Indonesia**,
-[বাংলা][BD_BN],
 [Català][CA],
 [Deutsch][DE],
 [English][EN],
@@ -19,13 +18,15 @@
 [العربية][AR],
 [فارسی][FA],
 [हिंदी][HI_IN],
+[বাংলা][BD_BN],
+[မြန်မာ][MM],
 [日本][JA],
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
 [한국어][KO_KR]
-[မြန်မာ][MM]
 
 [AR]:README.ar.md
+[BD_BN]:README.bd_bn.md
 [CA]:README.ca.md
 [DE]:README.de.md
 [EN]:README.md
@@ -37,6 +38,7 @@
 [IT]:README.it.md
 [JA]:README.ja.md
 [KO_KR]:README.ko_kr.md
+[MM]:README.mm.md
 [PL]:README.pl.md
 [PT_BR]:README.pt_br.md
 [RO]:README.ro.md

--- a/README.id.md
+++ b/README.id.md
@@ -3,6 +3,7 @@
 
 :crossed_flags:
 **Bahasa Indonesia**,
+[বাংলা][BD_BN],
 [Català][CA],
 [Deutsch][DE],
 [English][EN],

--- a/README.it.md
+++ b/README.it.md
@@ -23,6 +23,7 @@
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
 [한국어][KO_KR]
+[မြန်မာ][MM]
 
 [AR]:README.ar.md
 [CA]:README.ca.md

--- a/README.it.md
+++ b/README.it.md
@@ -3,7 +3,6 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
-[বাংলা][BD_BN],
 [Català][CA],
 [Deutsch][DE],
 [English][EN],
@@ -19,13 +18,15 @@
 [العربية][AR],
 [فارسی][FA],
 [हिंदी][HI_IN],
+[বাংলা][BD_BN],
+[မြန်မာ][MM],
 [日本][JA],
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
 [한국어][KO_KR]
-[မြန်မာ][MM]
 
 [AR]:README.ar.md
+[BD_BN]:README.bd_bn.md
 [CA]:README.ca.md
 [DE]:README.de.md
 [EN]:README.md
@@ -37,6 +38,7 @@
 [IT]:README.it.md
 [JA]:README.ja.md
 [KO_KR]:README.ko_kr.md
+[MM]:README.mm.md
 [PL]:README.pl.md
 [PT_BR]:README.pt_br.md
 [RO]:README.ro.md

--- a/README.it.md
+++ b/README.it.md
@@ -3,6 +3,7 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
+[বাংলা][BD_BN],
 [Català][CA],
 [Deutsch][DE],
 [English][EN],

--- a/README.ja.md
+++ b/README.ja.md
@@ -3,7 +3,6 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
-[বাংলা][BD_BN],
 [Català][CA],
 [Deutsch][DE],
 [English][EN],
@@ -19,12 +18,15 @@
 [العربية][AR],
 [فارسی][FA],
 [हिंदी][HI_IN],
+[বাংলা][BD_BN],
+[မြန်မာ][MM],
 **日本**,
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
 [한국어][KO_KR]
 
 [AR]:README.ar.md
+[BD_BN]:README.bd_bn.md
 [CA]:README.ca.md
 [DE]:README.de.md
 [EN]:README.md
@@ -36,6 +38,7 @@
 [IT]:README.it.md
 [JA]:README.ja.md
 [KO_KR]:README.ko_kr.md
+[MM]:README.mm.md
 [PL]:README.pl.md
 [PT_BR]:README.pt_br.md
 [RO]:README.ro.md

--- a/README.ja.md
+++ b/README.ja.md
@@ -3,6 +3,7 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
+[বাংলা][BD_BN],
 [Català][CA],
 [Deutsch][DE],
 [English][EN],

--- a/README.ko_kr.md
+++ b/README.ko_kr.md
@@ -23,6 +23,7 @@
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
 **한국어**
+[မြန်မာ][MM]
 
 [AR]:README.ar.md
 [CA]:README.ca.md

--- a/README.ko_kr.md
+++ b/README.ko_kr.md
@@ -3,7 +3,6 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
-[বাংলা][BD_BN],
 [Català][CA],
 [Deutsch][DE],
 [English][EN],
@@ -19,13 +18,15 @@
 [العربية][AR],
 [فارسی][FA],
 [हिंदी][HI_IN],
+[বাংলা][BD_BN],
+[မြန်မာ][MM],
 [日本][JA],
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
 **한국어**
-[မြန်မာ][MM]
 
 [AR]:README.ar.md
+[BD_BN]:README.bd_bn.md
 [CA]:README.ca.md
 [DE]:README.de.md
 [EN]:README.md
@@ -37,6 +38,7 @@
 [IT]:README.it.md
 [JA]:README.ja.md
 [KO_KR]:README.ko_kr.md
+[MM]:README.mm.md
 [PL]:README.pl.md
 [PT_BR]:README.pt_br.md
 [RO]:README.ro.md

--- a/README.ko_kr.md
+++ b/README.ko_kr.md
@@ -3,6 +3,7 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
+[বাংলা][BD_BN],
 [Català][CA],
 [Deutsch][DE],
 [English][EN],

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
-[বাংলা][BD_BN],
 [Català][CA],
 [Deutsch][DE],
 **English**,
@@ -19,12 +18,15 @@
 [العربية][AR],
 [فارسی][FA],
 [हिंदी][HI_IN],
+[বাংলা][BD_BN],
+[မြန်မာ][MM],
 [日本][JA],
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
 [한국어][KO_KR]
 
 [AR]:README.ar.md
+[BD_BN]:README.bd_bn.md
 [CA]:README.ca.md
 [DE]:README.de.md
 [EN]:README.md
@@ -36,6 +38,7 @@
 [IT]:README.it.md
 [JA]:README.ja.md
 [KO_KR]:README.ko_kr.md
+[MM]:README.mm.md
 [PL]:README.pl.md
 [PT_BR]:README.pt_br.md
 [RO]:README.ro.md

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
+[বাংলা][BD_BN],
 [Català][CA],
 [Deutsch][DE],
 **English**,

--- a/README.mm.md
+++ b/README.mm.md
@@ -1,0 +1,91 @@
+# Apollo-11
+[![NASA][1]][2]
+
+:crossed_flags:
+[Bahasa Indonesia][ID],
+[Català][CA],
+[Deutsch][DE],
+[English][EN],
+[Español][ES],
+[Français][FR],
+[Italiano][IT],
+[Português][PT_BR],
+[Русский][RU],
+[العربية][AR],
+[हिंदी][HI_IN],
+[正體中文][ZH_TW],
+[简体中文][ZH_CN],
+[한국어][KO_KR],
+[日本][JA],
+**မြန်မာ**
+
+[AR]:README.ar.md
+[ID]:README.id.md
+[CA]:README.ca.md
+[DE]:README.de.md
+[EN]:README.md
+[ES]:README.es.md
+[IT]:README.it.md
+[FR]:README.fr.md
+[JA]:README.ja.md
+[PT_BR]:README.pt_br.md
+[ZH_TW]:README.zh_tw.md
+[ZH_CN]:README.zh_cn.md
+[KO_KR]:README.ko_kr.md
+[HI_IN]:README.hi_in.md
+[RU]:README.ru.md
+[MM]:README.mm.md
+
+
+မူရင်း Apollo 11​​ ထိန်းချုပ်မှု ကွန်ပျူတာ (AGC) တွင်ပါဝင်သော ကွပ်ကဲမှုအစိတ်အပိုင်း (Comanche055) နဲ့ လပေါ်တွင်ဆင်းသက်သည့် အစိတ်အပိုင်း (Luminary099) တို့ရဲ့ ကုဒ်။ [Virtual AGC][3] နှင့် [MIT Museum][4] အကူအညီဖြင့် ဒီဂျစ်တယ်ပုံစံသို့ ပြောင်းထားခြင်းဖြစ်သည်။​ မူရင်း Apollo 11 ကုဒ်များ သိမ်းစည်းထားသော ရီပိုတစ်ခုဖြစ်လာစေရန်ရည်ရွယ်သည်။ ဒါကြောင့် [Luminary 099][5] နဲ့ [Comanche 055][6] တို့ရဲ့ အရင်းအမြစ်စာတမ်းများနဲ့ ဒီရီပိုကြား ကွဲလွဲချက်များတွေ့ရင် Pull Request (PR) တွေဖွင့်ပေးဖို့ ကြိုဆိုပါတယ်။ ကျွန်တော် ကျန်ခဲ့တဲ့ ဖိုင်လ်လေးတွေရှိရင်လည်း ပြောပေးကြပါဉီး။
+
+## ပါဝင်ကူညီပေးခြင်း
+Pull Request မဖွင့်ခင် [CONTRIBUTING.md][7] ကိုတော့ဖတ်ပေးနော်။
+
+## Compiling
+မူလကုဒ်ကို ကွန်ပိုင်းချင်တယ်ဆိုရင်တော့ [Virtual AGC][8] မှာစမ်းကြည့်လို့ရတယ်နော် 
+
+## မှီညှမ်းခြင်း
+
+
+&nbsp;         | &nbsp;
+:------------- | :-----
+မူပိုင်ခွင့်      | မူပိုင်မဲ့ အများပိုင်
+Comanche055    | Colossus 2A ၏ ကုဒ်အစိတ်အပိုင်း၊ Apollo 11 အတွက် ကွပ်ကဲမှုအစိတ်အပိုင်း (CM) ၏ Apollo ထိန်းချုပ်မှု ကွန်ပျူတာ (AGC)<br>`Assemble revision 055 of AGC program Comanche by NASA`<br>`2021113-051. 10:28 APR. 1, 1969`
+Luminary099    | Luminary 1A ၏ ကုဒ်အစိတ်အပိုင်း၊ Apollo 11 တွင် လပေါ်တွင်ဆင်းသက်သည့် အစိတ်အပိုင်း (LM) ၏ Apollo ထိန်းချုပ်မှု ကွန်ပျူတာ (AGC)<br>`Assemble revision 001 of AGC program LYM99 by NASA`<br>`2021112-061. 16:27 JUL. 14, 1969`
+Assembler      | yaYUL
+ဆက်သွယ်ရန်        | Ron Burkey <info@sandroid.org>
+ဝဘ်ဆိုက်စာမျက်နှာ        | www.ibiblio.org/apollo
+ဒစ်ဂျစ်တယ်ပုံစံပြောင်းလဲခြင်း | ဤကုဒ်ကို MIT ပြတိုက် (MIT Musem) မှ စာတမ်းများကို ဒီဂျစ်တယ်ပုံများဖမ်းပြီး၊ ထိုမှတစ်ဆင့် ကုဒ်အသွင်သို့ ပြောင်းလဲထားခြင်းဖြစ်သည်။ ဒီဂျစ်တယ်ပုံစံပြောင်းလဲခြင်း ကို Paul Fjeld မှပြုလုပ်ပေးခဲ့ပြီး၊ ပြတိုက်မှ Deborah Douglas ကစီစဉ်ပေးခဲ့သည်။ နှစ်ယောက်လုံးကို ကျေးဇူးအများကြီးတင်ပါတယ်။
+
+
+
+### စာချုပ်နှင့် ခွင့်ပြုချုက်များ
+*Derived from [CONTRACT_AND_APPROVALS.agc]*
+
+ဤ AGC ပရိုဂရမ် ကို Colossus 2A ဟူ၍ ခေါ်ဝေါ်မည်။
+
+ဤပရိုဂရမ် ကို CM တွင် `R-577` တင်ပြချက်အတိုင်း အသုံးပြုရန် ရည်ရွယ်ထားသည်။ Instrumentation Laboratory, Massachusetts Institute of Technology, Cambridge, Mass တို့နှင့်ချုပ်ခဲ့သော စာချုပ်  `NAS 9-4065` အရ Manned Spacecraft Center of The National Aeronautics and Space Administration ၏ ထောက်ပံ့မှုဖြင့် DSR ပရောဂျက် `55-23870` လက်အောက်တွင် ဤပရိုဂရမ်ကို  ပြင်ဆင်ခဲ့ခြင်းဖြစ်သည်။ 
+
+တင်ပြခဲ့သူ          | ရာထူး | ရက်စွဲ
+:-------------------- | :--- | :---
+Margaret H. Hamilton  | Colossus ပရိုဂရမ် ခေါင်းဆောင် <br>Apollo ထိန်းချုပ်မှုနဲ့ ရွေ့လျားခြင်း ပရိုဂရမ် | ၂၈ မတ်လ ၁၉၆၉
+
+ထောက်ခံ ခွင့်ပြုခဲ့သူ        | ရာထူး | ရက်စွဲ
+:----------------- | :--- | :---
+Daniel J. Lickly   | ဒါရိုက်တာ, Mission ပရိုဂရမ် ဖော်ဆောင်မှု<br>Apollo ထိန်းချုပ်မှုနဲ့ ရွေ့လျားခြင်း ပရိုဂရမ် | ၂၈ မတ်လ ၁၉၆၉
+Fred H. Martin     | Colossus ပရောဂျက် မန်နေဂျာ<br>Apollo ထိန်းချုပ်မှုနဲ့ ရွေ့လျားခြင်း ပရိုဂရမ် | ၂၈ မတ်လ ၁၉၆၉
+Norman E. Sears    | ညွှန်ကြားရေးမှူး, Mission ဖော်ဆောင်မှု<br>Apollo ထိန်းချုပ်မှုနဲ့ ရွေ့လျားခြင်း ပရိုဂရမ် | ၂၈ မတ်လ ၁၉၆၉
+Richard H. Battin  | ညွှန်ကြားရေးမှူး, Mission ဖော်ဆောင်မှု<br>Apollo ထိန်းချုပ်မှုနဲ့ ရွေ့လျားခြင်း ပရိုဂရမ် | ၂၈ မတ်လ ၁၉၆၉
+David G. Hoag      | ညွှန်ကြားရေးမှူး<br>Apollo ထိန်းချုပ်မှုနဲ့ ရွေ့လျားခြင်း ပရိုဂရမ် | ၂၈ မတ်လ ၁၉၆၉
+Ralph R. Ragan     | ဒုတိယညွှန်ကြားရေးမှူး<br>Instrumentation Laboratory | ၂၈ မတ်လ ၁၉၆၉
+
+[CONTRACT_AND_APPROVALS.agc]:https://github.com/chrislgarry/Apollo-11/blob/master/Comanche055/CONTRACT_AND_APPROVALS.agc
+[1]:https://rawcdn.githack.com/aleen42/badges/c9246f74/src/nasa.svg
+[2]:https://www.nasa.gov/mission_pages/apollo/missions/apollo11.html
+[3]:http://www.ibiblio.org/apollo/
+[4]:http://web.mit.edu/museum/
+[5]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
+[6]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
+[7]:https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.md
+[8]:https://github.com/rburkey2005/virtualagc

--- a/README.mm.md
+++ b/README.mm.md
@@ -9,32 +9,44 @@
 [Español][ES],
 [Français][FR],
 [Italiano][IT],
+[Polski][PL],
 [Português][PT_BR],
+[Română][RO],
+[Tiếng Việt][VI],
+[Türkçe][TR],
 [Русский][RU],
 [العربية][AR],
+[فارسی][FA],
 [हिंदी][HI_IN],
+[বাংলা][BD_BN],
+**မြန်မာ**,
+[日本][JA],
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
-[한국어][KO_KR],
-[日本][JA],
-**မြန်မာ**
+[한국어][KO_KR]
 
 [AR]:README.ar.md
-[ID]:README.id.md
+[BD_BN]:README.bd_bn.md
 [CA]:README.ca.md
 [DE]:README.de.md
 [EN]:README.md
 [ES]:README.es.md
-[IT]:README.it.md
+[FA]:README.fa.md
 [FR]:README.fr.md
-[JA]:README.ja.md
-[PT_BR]:README.pt_br.md
-[ZH_TW]:README.zh_tw.md
-[ZH_CN]:README.zh_cn.md
-[KO_KR]:README.ko_kr.md
 [HI_IN]:README.hi_in.md
-[RU]:README.ru.md
+[ID]:README.id.md
+[IT]:README.it.md
+[JA]:README.ja.md
+[KO_KR]:README.ko_kr.md
 [MM]:README.mm.md
+[PL]:README.pl.md
+[PT_BR]:README.pt_br.md
+[RO]:README.ro.md
+[RU]:README.ru.md
+[TR]:README.tr.md
+[VI]:README.vi.md
+[ZH_CN]:README.zh_cn.md
+[ZH_TW]:README.zh_tw.md
 
 
 မူရင်း Apollo 11​​ ထိန်းချုပ်မှု ကွန်ပျူတာ (AGC) တွင်ပါဝင်သော ကွပ်ကဲမှုအစိတ်အပိုင်း (Comanche055) နဲ့ လပေါ်တွင်ဆင်းသက်သည့် အစိတ်အပိုင်း (Luminary099) တို့ရဲ့ ကုဒ်။ [Virtual AGC][3] နှင့် [MIT Museum][4] အကူအညီဖြင့် ဒီဂျစ်တယ်ပုံစံသို့ ပြောင်းထားခြင်းဖြစ်သည်။​ မူရင်း Apollo 11 ကုဒ်များ သိမ်းစည်းထားသော ရီပိုတစ်ခုဖြစ်လာစေရန်ရည်ရွယ်သည်။ ဒါကြောင့် [Luminary 099][5] နဲ့ [Comanche 055][6] တို့ရဲ့ အရင်းအမြစ်စာတမ်းများနဲ့ ဒီရီပိုကြား ကွဲလွဲချက်များတွေ့ရင် Pull Request (PR) တွေဖွင့်ပေးဖို့ ကြိုဆိုပါတယ်။ ကျွန်တော် ကျန်ခဲ့တဲ့ ဖိုင်လ်လေးတွေရှိရင်လည်း ပြောပေးကြပါဉီး။
@@ -43,7 +55,7 @@
 Pull Request မဖွင့်ခင် [CONTRIBUTING.md][7] ကိုတော့ဖတ်ပေးနော်။
 
 ## Compiling
-မူလကုဒ်ကို ကွန်ပိုင်းချင်တယ်ဆိုရင်တော့ [Virtual AGC][8] မှာစမ်းကြည့်လို့ရတယ်နော် 
+မူလကုဒ်ကို ကွန်ပိုင်းချင်တယ်ဆိုရင်တော့ [Virtual AGC][8] မှာစမ်းကြည့်လို့ရတယ်နော်
 
 ## မှီညှမ်းခြင်း
 
@@ -65,7 +77,7 @@ Assembler      | yaYUL
 
 ဤ AGC ပရိုဂရမ် ကို Colossus 2A ဟူ၍ ခေါ်ဝေါ်မည်။
 
-ဤပရိုဂရမ် ကို CM တွင် `R-577` တင်ပြချက်အတိုင်း အသုံးပြုရန် ရည်ရွယ်ထားသည်။ Instrumentation Laboratory, Massachusetts Institute of Technology, Cambridge, Mass တို့နှင့်ချုပ်ခဲ့သော စာချုပ်  `NAS 9-4065` အရ Manned Spacecraft Center of The National Aeronautics and Space Administration ၏ ထောက်ပံ့မှုဖြင့် DSR ပရောဂျက် `55-23870` လက်အောက်တွင် ဤပရိုဂရမ်ကို  ပြင်ဆင်ခဲ့ခြင်းဖြစ်သည်။ 
+ဤပရိုဂရမ် ကို CM တွင် `R-577` တင်ပြချက်အတိုင်း အသုံးပြုရန် ရည်ရွယ်ထားသည်။ Instrumentation Laboratory, Massachusetts Institute of Technology, Cambridge, Mass တို့နှင့်ချုပ်ခဲ့သော စာချုပ်  `NAS 9-4065` အရ Manned Spacecraft Center of The National Aeronautics and Space Administration ၏ ထောက်ပံ့မှုဖြင့် DSR ပရောဂျက် `55-23870` လက်အောက်တွင် ဤပရိုဂရမ်ကို  ပြင်ဆင်ခဲ့ခြင်းဖြစ်သည်။
 
 တင်ပြခဲ့သူ          | ရာထူး | ရက်စွဲ
 :-------------------- | :--- | :---

--- a/README.pl.md
+++ b/README.pl.md
@@ -18,12 +18,15 @@
 [العربية][AR],
 [فارسی][FA],
 [हिंदी][HI_IN],
+[বাংলা][BD_BN],
+[မြန်မာ][MM],
 [日本][JA],
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
 [한국어][KO_KR]
 
 [AR]:README.ar.md
+[BD_BN]:README.bd_bn.md
 [CA]:README.ca.md
 [DE]:README.de.md
 [EN]:README.md
@@ -35,6 +38,7 @@
 [IT]:README.it.md
 [JA]:README.ja.md
 [KO_KR]:README.ko_kr.md
+[MM]:README.mm.md
 [PL]:README.pl.md
 [PT_BR]:README.pt_br.md
 [RO]:README.ro.md

--- a/README.pt_br.md
+++ b/README.pt_br.md
@@ -23,6 +23,7 @@
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
 [한국어][KO_KR]
+[မြန်မာ][MM]
 
 [AR]:README.ar.md
 [CA]:README.ca.md

--- a/README.pt_br.md
+++ b/README.pt_br.md
@@ -3,7 +3,6 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
-[বাংলা][BD_BN],
 [Català][CA],
 [Deutsch][DE],
 [English][EN],
@@ -19,13 +18,15 @@
 [العربية][AR],
 [فارسی][FA],
 [हिंदी][HI_IN],
+[বাংলা][BD_BN],
+[မြန်မာ][MM],
 [日本][JA],
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
 [한국어][KO_KR]
-[မြန်မာ][MM]
 
 [AR]:README.ar.md
+[BD_BN]:README.bd_bn.md
 [CA]:README.ca.md
 [DE]:README.de.md
 [EN]:README.md
@@ -37,6 +38,7 @@
 [IT]:README.it.md
 [JA]:README.ja.md
 [KO_KR]:README.ko_kr.md
+[MM]:README.mm.md
 [PL]:README.pl.md
 [PT_BR]:README.pt_br.md
 [RO]:README.ro.md

--- a/README.pt_br.md
+++ b/README.pt_br.md
@@ -3,6 +3,7 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
+[বাংলা][BD_BN],
 [Català][CA],
 [Deutsch][DE],
 [English][EN],

--- a/README.ro.md
+++ b/README.ro.md
@@ -18,12 +18,15 @@
 [العربية][AR],
 [فارسی][FA],
 [हिंदी][HI_IN],
+[বাংলা][BD_BN],
+[မြန်မာ][MM],
 [日本][JA],
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
 [한국어][KO_KR]
 
 [AR]:README.ar.md
+[BD_BN]:README.bd_bn.md
 [CA]:README.ca.md
 [DE]:README.de.md
 [EN]:README.md
@@ -35,6 +38,7 @@
 [IT]:README.it.md
 [JA]:README.ja.md
 [KO_KR]:README.ko_kr.md
+[MM]:README.mm.md
 [PL]:README.pl.md
 [PT_BR]:README.pt_br.md
 [RO]:README.ro.md

--- a/README.ru.md
+++ b/README.ru.md
@@ -23,6 +23,7 @@
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
 [한국어][KO_KR]
+[မြန်မာ][MM]
 
 [AR]:README.ar.md
 [CA]:README.ca.md

--- a/README.ru.md
+++ b/README.ru.md
@@ -3,7 +3,6 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
-[বাংলা][BD_BN],
 [Català][CA],
 [Deutsch][DE],
 [English][EN],
@@ -19,13 +18,15 @@
 [العربية][AR],
 [فارسی][FA],
 [हिंदी][HI_IN],
+[বাংলা][BD_BN],
+[မြန်မာ][MM],
 [日本][JA],
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
 [한국어][KO_KR]
-[မြန်မာ][MM]
 
 [AR]:README.ar.md
+[BD_BN]:README.bd_bn.md
 [CA]:README.ca.md
 [DE]:README.de.md
 [EN]:README.md
@@ -37,6 +38,7 @@
 [IT]:README.it.md
 [JA]:README.ja.md
 [KO_KR]:README.ko_kr.md
+[MM]:README.mm.md
 [PL]:README.pl.md
 [PT_BR]:README.pt_br.md
 [RO]:README.ro.md

--- a/README.ru.md
+++ b/README.ru.md
@@ -3,6 +3,7 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
+[বাংলা][BD_BN],
 [Català][CA],
 [Deutsch][DE],
 [English][EN],

--- a/README.tr.md
+++ b/README.tr.md
@@ -18,12 +18,15 @@
 [العربية][AR],
 [فارسی][FA],
 [हिंदी][HI_IN],
+[বাংলা][BD_BN],
+[မြန်မာ][MM],
 [日本][JA],
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
 [한국어][KO_KR]
 
 [AR]:README.ar.md
+[BD_BN]:README.bd_bn.md
 [CA]:README.ca.md
 [DE]:README.de.md
 [EN]:README.md
@@ -35,6 +38,7 @@
 [IT]:README.it.md
 [JA]:README.ja.md
 [KO_KR]:README.ko_kr.md
+[MM]:README.mm.md
 [PL]:README.pl.md
 [PT_BR]:README.pt_br.md
 [RO]:README.ro.md

--- a/README.vi.md
+++ b/README.vi.md
@@ -18,12 +18,15 @@
 [العربية][AR],
 [فارسی][FA],
 [हिंदी][HI_IN],
+[বাংলা][BD_BN],
+[မြန်မာ][MM],
 [日本][JA],
 [正體中文][ZH_TW],
 [简体中文][ZH_CN],
 [한국어][KO_KR]
 
 [AR]:README.ar.md
+[BD_BN]:README.bd_bn.md
 [CA]:README.ca.md
 [DE]:README.de.md
 [EN]:README.md
@@ -35,6 +38,7 @@
 [IT]:README.it.md
 [JA]:README.ja.md
 [KO_KR]:README.ko_kr.md
+[MM]:README.mm.md
 [PL]:README.pl.md
 [PT_BR]:README.pt_br.md
 [RO]:README.ro.md

--- a/README.zh_cn.md
+++ b/README.zh_cn.md
@@ -3,7 +3,6 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
-[বাংলা][BD_BN],
 [Català][CA],
 [Deutsch][DE],
 [English][EN],
@@ -19,13 +18,15 @@
 [العربية][AR],
 [فارسی][FA],
 [हिंदी][HI_IN],
+[বাংলা][BD_BN],
+[မြန်မာ][MM],
 [日本][JA],
 [正體中文][ZH_TW],
 **简体中文**,
 [한국어][KO_KR]
-[မြန်မာ][MM]
 
 [AR]:README.ar.md
+[BD_BN]:README.bd_bn.md
 [CA]:README.ca.md
 [DE]:README.de.md
 [EN]:README.md
@@ -37,6 +38,7 @@
 [IT]:README.it.md
 [JA]:README.ja.md
 [KO_KR]:README.ko_kr.md
+[MM]:README.mm.md
 [PL]:README.pl.md
 [PT_BR]:README.pt_br.md
 [RO]:README.ro.md

--- a/README.zh_cn.md
+++ b/README.zh_cn.md
@@ -3,6 +3,7 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
+[বাংলা][BD_BN],
 [Català][CA],
 [Deutsch][DE],
 [English][EN],

--- a/README.zh_cn.md
+++ b/README.zh_cn.md
@@ -23,6 +23,7 @@
 [正體中文][ZH_TW],
 **简体中文**,
 [한국어][KO_KR]
+[မြန်မာ][MM]
 
 [AR]:README.ar.md
 [CA]:README.ca.md

--- a/README.zh_tw.md
+++ b/README.zh_tw.md
@@ -3,7 +3,6 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
-[বাংলা][BD_BN],
 [Català][CA],
 [Deutsch][DE],
 [English][EN],
@@ -19,13 +18,15 @@
 [العربية][AR],
 [فارسی][FA],
 [हिंदी][HI_IN],
+[বাংলা][BD_BN],
+[မြန်မာ][MM],
 [日本][JA],
 **正體中文**,
 [简体中文][ZH_CN],
 [한국어][KO_KR]
-[မြန်မာ][MM]
 
 [AR]:README.ar.md
+[BD_BN]:README.bd_bn.md
 [CA]:README.ca.md
 [DE]:README.de.md
 [EN]:README.md
@@ -37,6 +38,7 @@
 [IT]:README.it.md
 [JA]:README.ja.md
 [KO_KR]:README.ko_kr.md
+[MM]:README.mm.md
 [PL]:README.pl.md
 [PT_BR]:README.pt_br.md
 [RO]:README.ro.md

--- a/README.zh_tw.md
+++ b/README.zh_tw.md
@@ -3,6 +3,7 @@
 
 :crossed_flags:
 [Bahasa Indonesia][ID],
+[বাংলা][BD_BN],
 [Català][CA],
 [Deutsch][DE],
 [English][EN],

--- a/README.zh_tw.md
+++ b/README.zh_tw.md
@@ -23,6 +23,7 @@
 **正體中文**,
 [简体中文][ZH_CN],
 [한국어][KO_KR]
+[မြန်မာ][MM]
 
 [AR]:README.ar.md
 [CA]:README.ca.md


### PR DESCRIPTION
- Adds #534 and #415 with layout changes to match master applied
- Extends https://github.com/chrislgarry/Apollo-11/pull/555#issuecomment-572212230 by changing the commas in the Persian README language list to Arabic commas (matching comma usage in the README body)