### PR TITLE
Changed charset in .editorconfig 'utf8' to 'utf-8'

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 root = true
 
 [*]
-charset = utf8
+charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true


### PR DESCRIPTION
I noticed that the charset configuration present in _.editorconfig_ was **not working** for my text editor, so i realized that it was `utf8`  when it should be `utf-8`