### PR TITLE
ci(markdownlint): upgrade actions/checkout to v3

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -5,6 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Run mdl
       uses: actionshub/markdownlint@2.0.2


### PR DESCRIPTION
Update `actions/checkout` to `v3` in `.github/workflows/markdownlint`