### PR TITLE
docs: fix translation contribution links in README files

### DIFF
--- a/Translations/README.ar.md
+++ b/Translations/README.ar.md
@@ -134,7 +134,7 @@ Luminary099    | جزء من الكود المصدري للنظامLuminary 1A،
 [4]:http://web.mit.edu/museum/
 [5]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [6]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[7]:https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.ar.md
+[7]:https://github.com/chrislgarry/Apollo-11/blob/master/Translations/CONTRIBUTING.ar.md
 [8]:https://github.com/rburkey2005/virtualagc
 [SWH]:https://flat.badgen.net/badge/Software%20Heritage/Archive/0B3D91
 [SWH_URL]:https://archive.softwareheritage.org/browse/origin/https://github.com/chrislgarry/Apollo-11/

--- a/Translations/README.as_in.md
+++ b/Translations/README.as_in.md
@@ -130,7 +130,7 @@ Ralph R. Ragan    | সহকারী পরিচালক<br>ইন্সট�
 [4]:http://web.mit.edu/museum/
 [5]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [6]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[7]:https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.md
+[7]:https://github.com/chrislgarry/Apollo-11/blob/master/Translations/CONTRIBUTING.md
 [8]:https://github.com/rburkey2005/virtualagc
 [SWH]:https://flat.badgen.net/badge/Software%20Heritage/Archive/0B3D91
 [SWH_URL]:https://archive.softwareheritage.org/browse/origin/https://github.com/chrislgarry/Apollo-11/

--- a/Translations/README.az.md
+++ b/Translations/README.az.md
@@ -130,7 +130,7 @@ Ralph R. Ragan       | Direktor köməkçisi<br>Alətlər Laboratoriyası       
 [4]:http://web.mit.edu/museum/
 [5]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [6]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[7]:https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.tr.md
+[7]:https://github.com/chrislgarry/Apollo-11/blob/master/Translations/CONTRIBUTING.tr.md
 [8]:https://github.com/rburkey2005/virtualagc
 [SWH]:https://flat.badgen.net/badge/Software%20Heritage/Archive/0B3D91
 [SWH_URL]:https://archive.softwareheritage.org/browse/origin/https://github.com/chrislgarry/Apollo-11/

--- a/Translations/README.cz.md
+++ b/Translations/README.cz.md
@@ -130,7 +130,7 @@ Ralph R. Ragan    | Zástupce ředitele<br>Laboratoř instrumentace | 28. Březn
 [4]:http://web.mit.edu/museum/
 [5]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [6]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[7]:https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.cz.md
+[7]:https://github.com/chrislgarry/Apollo-11/blob/master/Translations/CONTRIBUTING.cz.md
 [8]:https://github.com/rburkey2005/virtualagc
 [SWH]:https://flat.badgen.net/badge/Software%20Heritage/Archive/0B3D91
 [SWH_URL]:https://archive.softwareheritage.org/browse/origin/https://github.com/chrislgarry/Apollo-11/

--- a/Translations/README.da.md
+++ b/Translations/README.da.md
@@ -131,7 +131,7 @@ Ralph R. Ragan    | Vicedirektør<br>Instrumentlaboratoriet | 28 Mar 69
 [4]:http://web.mit.edu/museum/
 [5]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [6]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[7]:https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.da.md
+[7]:https://github.com/chrislgarry/Apollo-11/blob/master/Translations/CONTRIBUTING.da.md
 [8]:https://github.com/rburkey2005/virtualagc
 [SWH]:https://flat.badgen.net/badge/Software%20Heritage/Archive/0B3D91
 [SWH_URL]:https://archive.softwareheritage.org/browse/origin/https://github.com/chrislgarry/Apollo-11/

--- a/Translations/README.de.md
+++ b/Translations/README.de.md
@@ -130,7 +130,7 @@ Ralph R. Ragan    | Stellvertretender Direktor<br>Instrumentation Laboratory | 2
 [4]:http://web.mit.edu/museum/
 [5]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [6]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[7]:https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.de.md
+[7]:https://github.com/chrislgarry/Apollo-11/blob/master/Translations/CONTRIBUTING.de.md
 [8]:https://github.com/rburkey2005/virtualagc
 [SWH]:https://flat.badgen.net/badge/Software%20Heritage/Archive/0B3D91
 [SWH_URL]:https://archive.softwareheritage.org/browse/origin/https://github.com/chrislgarry/Apollo-11/

--- a/Translations/README.es.md
+++ b/Translations/README.es.md
@@ -130,7 +130,7 @@ Ralph R. Ragan    | Subdirector del Laboratorio de Instrumentación | 28 mar 69
 [4]:http://web.mit.edu/museum/
 [5]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [6]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[7]:https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.es.md
+[7]:https://github.com/chrislgarry/Apollo-11/blob/master/Translations/CONTRIBUTING.es.md
 [8]:https://github.com/rburkey2005/virtualagc
 [SWH]:https://flat.badgen.net/badge/Software%20Heritage/Archive/0B3D91
 [SWH_URL]:https://archive.softwareheritage.org/browse/origin/https://github.com/chrislgarry/Apollo-11/

--- a/Translations/README.fr.md
+++ b/Translations/README.fr.md
@@ -139,7 +139,7 @@ Ralph R. Ragan    | Directeur adjoint<br>Laboratoire d'instrumentation | 28 Mar 
 [4]:http://web.mit.edu/museum/
 [5]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [6]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[7]:https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.fr.md
+[7]:https://github.com/chrislgarry/Apollo-11/blob/master/Translations/CONTRIBUTING.fr.md
 [8]:https://github.com/rburkey2005/virtualagc
 [SWH]:https://flat.badgen.net/badge/Software%20Heritage/Archive/0B3D91
 [SWH_URL]:https://archive.softwareheritage.org/browse/origin/https://github.com/chrislgarry/Apollo-11/

--- a/Translations/README.gl.md
+++ b/Translations/README.gl.md
@@ -130,7 +130,7 @@ Ralph R. Ragan    | Subdirector do Laboratorio de Instrumentación | 28 mar 69
 [4]:http://web.mit.edu/museum/
 [5]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [6]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[7]:https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.gl.md
+[7]:https://github.com/chrislgarry/Apollo-11/blob/master/Translations/CONTRIBUTING.gl.md
 [8]:https://github.com/rburkey2005/virtualagc
 [SWH]:https://flat.badgen.net/badge/Software%20Heritage/Archive/0B3D91
 [SWH_URL]:https://archive.softwareheritage.org/browse/origin/https://github.com/chrislgarry/Apollo-11/

--- a/Translations/README.gr.md
+++ b/Translations/README.gr.md
@@ -130,7 +130,7 @@ Ralph R. Ragan    | Αναπληρωτής Διευθυντής<br>Instrumentati
 [4]:http://web.mit.edu/museum/
 [5]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [6]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[7]:https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.gr.md
+[7]:https://github.com/chrislgarry/Apollo-11/blob/master/Translations/CONTRIBUTING.gr.md
 [8]:https://github.com/rburkey2005/virtualagc
 [SWH]:https://flat.badgen.net/badge/Software%20Heritage/Archive/0B3D91
 [SWH_URL]:https://archive.softwareheritage.org/browse/origin/https://github.com/chrislgarry/Apollo-11/

--- a/Translations/README.it.md
+++ b/Translations/README.it.md
@@ -130,7 +130,7 @@ Ralph R. Ragan    | Vice direttore<br>Instrumentation Laboratory | 28 Mar 69
 [4]:http://web.mit.edu/museum/
 [5]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [6]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[7]:https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.it.md
+[7]:https://github.com/chrislgarry/Apollo-11/blob/master/Translations/CONTRIBUTING.it.md
 [8]:https://github.com/rburkey2005/virtualagc
 [SWH]:https://flat.badgen.net/badge/Software%20Heritage/Archive/0B3D91
 [SWH_URL]:https://archive.softwareheritage.org/browse/origin/https://github.com/chrislgarry/Apollo-11/

--- a/Translations/README.ja.md
+++ b/Translations/README.ja.md
@@ -130,7 +130,7 @@ Ralph R. Ragan    | 副ディレクター<br>機械研究所 | 1969年3月28日
 [4]:http://web.mit.edu/museum/
 [5]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [6]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[7]:https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.ja.md
+[7]:https://github.com/chrislgarry/Apollo-11/blob/master/Translations/CONTRIBUTING.ja.md
 [8]:https://github.com/rburkey2005/virtualagc
 [SWH]:https://flat.badgen.net/badge/Software%20Heritage/Archive/0B3D91
 [SWH_URL]:https://archive.softwareheritage.org/browse/origin/https://github.com/chrislgarry/Apollo-11/

--- a/Translations/README.ko_kr.md
+++ b/Translations/README.ko_kr.md
@@ -130,7 +130,7 @@ Ralph R. Ragan    | 부감독<br>기계 연구소 | 1969년 3월 28일
 [4]:http://web.mit.edu/museum/
 [5]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [6]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[7]:https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.ko_kr.md
+[7]:https://github.com/chrislgarry/Apollo-11/blob/master/Translations/CONTRIBUTING.ko_kr.md
 [8]:https://github.com/rburkey2005/virtualagc
 [SWH]:https://flat.badgen.net/badge/Software%20Heritage/Archive/0B3D91
 [SWH_URL]:https://archive.softwareheritage.org/browse/origin/https://github.com/chrislgarry/Apollo-11/

--- a/Translations/README.ku.md
+++ b/Translations/README.ku.md
@@ -130,7 +130,7 @@ Ralph R. Ragan    | Cîgirê Rêvebir<br>Laboratoriya Instrumentation | 28 Adar 
 [4]:http://web.mit.edu/museum/
 [5]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [6]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[7]:https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.ku.md
+[7]:https://github.com/chrislgarry/Apollo-11/blob/master/Translations/CONTRIBUTING.ku.md
 [8]:https://github.com/rburkey2005/virtualagc
 [SWH]:https://flat.badgen.net/badge/Software%20Heritage/Archive/0B3D91
 [SWH_URL]:https://archive.softwareheritage.org/browse/origin/https://github.com/chrislgarry/Apollo-11/

--- a/Translations/README.mn.md
+++ b/Translations/README.mn.md
@@ -130,7 +130,7 @@ Ralph R. Ragan    | Дэд захирал<br>Механик судалгааны
 [4]:http://web.mit.edu/museum/
 [5]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [6]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[7]:https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.ja.md
+[7]:https://github.com/chrislgarry/Apollo-11/blob/master/Translations/CONTRIBUTING.ja.md
 [8]:https://github.com/rburkey2005/virtualagc
 [SWH]:https://flat.badgen.net/badge/Software%20Heritage/Archive/0B3D91
 [SWH_URL]:https://archive.softwareheritage.org/browse/origin/https://github.com/chrislgarry/Apollo-11/

--- a/Translations/README.nl.md
+++ b/Translations/README.nl.md
@@ -130,7 +130,7 @@ Ralph R. Ragan    | Adjunct-directeur<br>Instrumentation Laboratory | 28 maart. 
 [4]:http://web.mit.edu/museum/
 [5]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [6]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[7]:https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.nl.md
+[7]:https://github.com/chrislgarry/Apollo-11/blob/master/Translations/CONTRIBUTING.nl.md
 [8]:https://github.com/rburkey2005/virtualagc
 [SWH]:https://flat.badgen.net/badge/Software%20Heritage/Archive/0B3D91
 [SWH_URL]:https://archive.softwareheritage.org/browse/origin/https://github.com/chrislgarry/Apollo-11/

--- a/Translations/README.no.md
+++ b/Translations/README.no.md
@@ -130,7 +130,7 @@ Ralph R. Ragan    | Deputy Director<br>Instrumentation Laboratory | 28 Mar 69
 [4]:http://web.mit.edu/museum/
 [5]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [6]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[7]:https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.no.md
+[7]:https://github.com/chrislgarry/Apollo-11/blob/master/Translations/CONTRIBUTING.no.md
 [8]:https://github.com/rburkey2005/virtualagc
 [SWH]:https://flat.badgen.net/badge/Software%20Heritage/Archive/0B3D91
 [SWH_URL]:https://archive.softwareheritage.org/browse/origin/https://github.com/chrislgarry/Apollo-11/

--- a/Translations/README.pl.md
+++ b/Translations/README.pl.md
@@ -130,7 +130,7 @@ Ralph R. Ragan     | Deputy Director<br>Instrumentation Laboratory | 28 Mar 69
 [4]:http://web.mit.edu/museum/
 [5]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [6]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[7]:https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.pl.md
+[7]:https://github.com/chrislgarry/Apollo-11/blob/master/Translations/CONTRIBUTING.pl.md
 [8]:https://github.com/rburkey2005/virtualagc
 [SWH]:https://flat.badgen.net/badge/Software%20Heritage/Archive/0B3D91
 [SWH_URL]:https://archive.softwareheritage.org/browse/origin/https://github.com/chrislgarry/Apollo-11/

--- a/Translations/README.pt_br.md
+++ b/Translations/README.pt_br.md
@@ -130,7 +130,7 @@ Ralph R. Ragan    | Vice Diretor<br>Laboratório de Instrumentação | 28 Mar 69
 [4]:http://web.mit.edu/museum/
 [5]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [6]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[7]:https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.pt_br.md
+[7]:https://github.com/chrislgarry/Apollo-11/blob/master/Translations/CONTRIBUTING.pt_br.md
 [8]:https://github.com/rburkey2005/virtualagc
 [SWH]:https://flat.badgen.net/badge/Software%20Heritage/Archive/0B3D91
 [SWH_URL]:https://archive.softwareheritage.org/browse/origin/https://github.com/chrislgarry/Apollo-11/

--- a/Translations/README.tr.md
+++ b/Translations/README.tr.md
@@ -130,7 +130,7 @@ Ralph R. Ragan    | Direktör Yardımcısı<br>Enstrümantasyon Laboratuvarı | 
 [4]:http://web.mit.edu/museum/
 [5]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [6]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[7]:https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.tr.md
+[7]:https://github.com/chrislgarry/Apollo-11/blob/master/Translations/CONTRIBUTING.tr.md
 [8]:https://github.com/rburkey2005/virtualagc
 [SWH]:https://flat.badgen.net/badge/Software%20Heritage/Archive/0B3D91
 [SWH_URL]:https://archive.softwareheritage.org/browse/origin/https://github.com/chrislgarry/Apollo-11/

--- a/Translations/README.zh_cn.md
+++ b/Translations/README.zh_cn.md
@@ -130,7 +130,7 @@ Ralph R. Ragan    | 副负责人<br>Instrumentation Laboratory | 1969 年 3 月 
 [4]:http://web.mit.edu/museum/
 [5]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
 [6]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
-[7]:https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.zh_cn.md
+[7]:https://github.com/chrislgarry/Apollo-11/blob/master/Translations/CONTRIBUTING.zh_cn.md
 [8]:https://github.com/rburkey2005/virtualagc
 [SWH]:https://flat.badgen.net/badge/Software%20Heritage/Archive/0B3D91
 [SWH_URL]:https://archive.softwareheritage.org/browse/origin/https://github.com/chrislgarry/Apollo-11/


### PR DESCRIPTION
## Description

This pull request fixes incorrect URLs for translation contribution guidelines in README files across multiple languages.

### Changes made:

- Updated translation contribution links in README files to point to the correct location
- Added "Translations/" to the path for each language's CONTRIBUTING file
- This change affects most non-English README files

### Example of change:

Before:
https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.cz.md

After:
https://github.com/chrislgarry/Apollo-11/blob/master/Translations/CONTRIBUTING.cz.md

### Why:
The previous links were pointing to an incorrect location, potentially confusing contributors interested in helping with translations. This fix ensures that links correctly direct to the appropriate contribution guidelines for each language, improving the contributor experience.

### Note:
Some README translations don't have a corresponding CONTRIBUTING file. In these cases, no changes were made to maintain consistency with the existing structure.

### Checklist:
- [x] Updated affected README files
- [x] Verified that all new links are correct and functional
- [x] Tested the changes by clicking on the links in the GitHub interface
- [x] Ensured no changes were made to READMEs without corresponding CONTRIBUTING files

Please review and let me know if any further changes or clarifications are needed ☺️