### PR TITLE
docs: add Sinhala (si) translation of README

### DIFF
--- a/Translations/README.si.md
+++ b/Translations/README.si.md
@@ -1,0 +1,148 @@
+# ඇපොලෝ-11
+
+[![NASA][1]][2]
+[![SWH]][SWH_URL]
+[![Comanche]][ComancheMilestone]
+[![Luminary]][LuminaryMilestone]
+
+🌐
+[Azerbaijani][AZ],
+[bahasa Indonesia][ID],
+[Català][CA],
+[Čeština][CZ],
+[Dansk][DA],
+[Deutsch][DE],
+[English][EN],
+[Español][ES],
+[Français][FR],
+[Galego][GL],
+[Italiano][IT],
+[Kurdî][KU],
+[Lietuvių][LT],
+[Mongolian][MN],
+[Nederlands][NL],
+[Norsk][NO],
+[Polski][PL],
+[Português][PT_BR],
+[Română][RO],
+[Svenska][SV],
+[tiếng Việt][VI],
+[Türkçe][TR],
+[Ελληνικά][GR],
+[Беларуская мова][BE],
+[Русский][RU],
+[Українська][UK],
+[العربية][AR],
+[فارسی][FA],
+[नेपाली भाषा][NE]
+[हिंदी][HI_IN],
+[অসমীয়া][AS_IN],
+[বাংলা][BD_BN],
+[မြန်မာ][MM],
+[한국어][KO_KR],
+[日本語][JA],
+[正體中文][ZH_TW],
+[简体中文][ZH_CN],
+[മലയാളം][ML],
+[සිංහල][SI]
+
+[AR]:Translations/README.ar.md
+[AS_IN]:Translations/README.as_in.md
+[AZ]:Translations/README.az.md
+[BD_BN]:Translations/README.bd_bn.md
+[BE]:Translations/README.be.md
+[CA]:Translations/README.ca.md
+[CZ]:Translations/README.cz.md
+[DA]:Translations/README.da.md
+[DE]:Translations/README.de.md
+[EN]:README.md
+[ES]:Translations/README.es.md
+[FA]:Translations/README.fa.md
+[FR]:Translations/README.fr.md
+[GL]:Translations/README.gl.md
+[GR]:Translations/README.gr.md
+[HI_IN]:Translations/README.hi_in.md
+[ID]:Translations/README.id.md
+[IT]:Translations/README.it.md
+[JA]:Translations/README.ja.md
+[KO_KR]:Translations/README.ko_kr.md
+[KU]:Translations/README.ku.md
+[LT]:Translations/README.lt.md
+[MM]:Translations/README.mm.md
+[MN]:Translations/README.mn.md
+[NE]:Translations/README.ne.md
+[NL]:Translations/README.nl.md
+[NO]:Translations/README.no.md
+[PL]:Translations/README.pl.md
+[PT_BR]:Translations/README.pt_br.md
+[RO]:Translations/README.ro.md
+[RU]:Translations/README.ru.md
+[SV]:Translations/README.sv.md
+[TR]:Translations/README.tr.md
+[UK]:Translations/README.uk.md
+[VI]:Translations/README.vi.md
+[ZH_CN]:Translations/README.zh_cn.md
+[ZH_TW]:Translations/README.zh_tw.md
+[ML]:Translations/README.ml.md
+[SI]:Translations/README.si.md
+
+මුල් ඇපොලෝ 11 මගගැසීම් පරිගණකය (AGC) සඳහා වූ මූලාශ්‍ර කේතය — Command Module (Comanche055) සහ Lunar Module (Luminary099) සඳහා. මෙය [Virtual AGC][3] සහ [MIT Museum][4] හි කණ්ඩායම් විසින් ඩිජිටල් කර ඇත.  
+මෙම repository එකේ අරමුණ වන්නේ මුල් ඇපොලෝ 11 මූලාශ්‍ර කේතය එකතැන් කිරීමයි. එබැවින්, මෙම repository එකේ ලියවිලි සහ මුල් Luminary 099 සහ Comanche 055 ස්කෑන් අතර වෙනසක් හෝ දෝෂයක් ඔබ සොයා ගත්තේ නම්, හෝ මම අමතක කළ ගොනු ඇත්නම්, ඒ සඳහා Pull Request (PR) එකක් යැවීමට සාදරයෙන් පිළිගනිමු.
+
+## දායකත්වය (Contributing)
+
+Pull Request එකක් යැවීමට පෙර කරුණාකර [CONTRIBUTING.md][7] කියවා බලන්න.
+
+## සංයුක්ත කිරීම (Compiling)
+
+ඔබට මුල් මූලාශ්‍ර කේතය compile කිරීමට අවශ්‍ය නම්, [Virtual AGC][8] බලන්න.
+
+## ස්තුති හා ප්‍රශංසා (Attribution)
+
+| &nbsp; | &nbsp; |
+| :------------- | :----- |
+| පිටපත් හිමිකම (Copyright) | Public domain |
+| Comanche055 | Apollo 11 හි Command Module (CM) සඳහා වූ Colossus 2A මූලාශ්‍ර කේත කොටසක්<br>`Assemble revision 055 of AGC program Comanche by NASA`<br>`2021113-051. 10:28 APR. 1, 1969` |
+| Luminary099 | Apollo 11 හි Lunar Module (LM) සඳහා වූ Luminary 1A මූලාශ්‍ර කේත කොටසක්<br>`Assemble revision 001 of AGC program LMY99 by NASA`<br>`2021112-061. 16:27 JUL. 14, 1969` |
+| අසැම්බ්ලර් (Assembler) | yaYUL |
+| සම්බන්ධවිය හැකි පුද්ගලයා | Ron Burkey <info@sandroid.org> |
+| වෙබ් අඩවිය | www.ibiblio.org/apollo |
+| ඩිජිටල් කිරීම | මෙම මූලාශ්‍ර කේතය MIT Museum හි hardcopy පිටපත් වලින් ඩිජිටල් කර අලුත් විධියකට පරිවර්තනය කර ඇත. ඩිජිටල් කිරීම සිදුකළේ Paul Fjeld විසින්ය, සහ Deborah Douglas විසින් MIT Museum වෙනුවෙන් ඒ සඳහා සහය දැක්වීය. දෙදෙනාටම ස්තුතියි. |
+
+### ගිවිසුම් සහ අනුමත කිරීම් (Contract and Approvals)
+
+*[CONTRACT_AND_APPROVALS.agc] සිට ආදේශ කර ඇත*
+
+මෙම AGC වැඩසටහන **Colossus 2A** ලෙසද හැඳින්වේ.
+
+මෙය Command Module තුළ භාවිතය සඳහා අදහස් කර ඇති වැඩසටහනකි, එය `R-577` වාර්තාවේ විස්තර කර ඇත.  
+මෙම වැඩසටහන DSR project `55-23870` යටතේ, NASA විසින් MIT හි Instrumentation Laboratory වෙත ලබාදුන් `NAS 9-4065` ගිවිසුම යටතේ සකස් කරන ලදී.
+
+| ඉදිරිපත් කළේ | භූමිකාව | දිනය |
+| :------------------- | :--- | :--- |
+| Margaret H. Hamilton | Colossus Programming Leader<br>Apollo Guidance and Navigation | 28 Mar 69 |
+
+| අනුමත කළේ | භූමිකාව | දිනය |
+| :---------------- | :--- | :--- |
+| Daniel J. Lickly | Director, Mission Program Development<br>Apollo Guidance and Navigation Program | 28 Mar 69 |
+| Fred H. Martin | Colossus Project Manager<br>Apollo Guidance and Navigation Program | 28 Mar 69 |
+| Norman E. Sears | Director, Mission Development<br>Apollo Guidance and Navigation Program | 28 Mar 69 |
+| Richard H. Battin | Director, Mission Development<br>Apollo Guidance and Navigation Program | 28 Mar 69 |
+| David G. Hoag | Director<br>Apollo Guidance and Navigation Program | 28 Mar 69 |
+| Ralph R. Ragan | Deputy Director<br>Instrumentation Laboratory | 28 Mar 69 |
+
+[CONTRACT_AND_APPROVALS.agc]:https://github.com/chrislgarry/Apollo-11/blob/master/Comanche055/CONTRACT_AND_APPROVALS.agc
+[1]:https://flat.badgen.net/badge/NASA/Mission%20Overview/0B3D91
+[2]:https://www.nasa.gov/mission_pages/apollo/missions/apollo11.html
+[3]:http://www.ibiblio.org/apollo/
+[4]:http://web.mit.edu/museum/
+[5]:http://www.ibiblio.org/apollo/ScansForConversion/Luminary099/
+[6]:http://www.ibiblio.org/apollo/ScansForConversion/Comanche055/
+[7]:https://github.com/chrislgarry/Apollo-11/blob/master/CONTRIBUTING.md
+[8]:https://github.com/rburkey2005/virtualagc
+[SWH]:https://flat.badgen.net/badge/Software%20Heritage/Archive/0B3D91
+[SWH_URL]:https://archive.softwareheritage.org/browse/origin/https://github.com/chrislgarry/Apollo-11/
+[Comanche]:https://flat.badgen.net/github/milestones/chrislgarry/Apollo-11/1
+[ComancheMilestone]:https://github.com/chrislgarry/Apollo-11/milestone/1
+[Luminary]:https://flat.badgen.net/github/milestones/chrislgarry/Apollo-11/2
+[LuminaryMilestone]:https://github.com/chrislgarry/Apollo-11/milestone/2


### PR DESCRIPTION
## Add Sinhala (si) translation of README

### Summary
This PR adds a Sinhala translation of the repository `README.md` at `Translations/README.si.md`. The goal is to make the Apollo‑11 project more accessible to Sinhala‑speaking contributors and readers.

### What I changed
- Added `Translations/README.si.md` — a full translation of the main README into Sinhala.

### Formatting & guidelines followed
- I followed the repository's translation and formatting conventions (see `CONTRIBUTING.md` and other files in `Translations/`).
- Tabs, trailing whitespace, and line breaks were kept consistent with the repo guidance.
- No changes were made to the original English README; this is an additional translation file only.

### Proofing checklist (please review)
- [ ] Translation accuracy and natural Sinhala phrasing
- [ ] Links, badges, and image references render correctly and match the original
- [ ] Headings, lists, and code blocks render properly on GitHub
- [ ] No unintended changes to repository-specific tokens (language link references, anchors, etc.)

### Why this is useful
- Improves accessibility for Sinhala speakers.
- Extends the project's multilingual documentation and invites more contributors.

### Notes for maintainers
- If you want wording or phrasing adjusted to match the project's tone, I can update the translation on this branch.
- I created this on branch `docs/translate-readme-si` (pushed to my fork).

---

**Hacktoberfest 2025** 🎃