### PR TITLE
chore: Update outdated GitHub Actions version

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
     - name: Lint markdown
       uses: DavidAnson/markdownlint-cli2-action@v19
       with:


### PR DESCRIPTION
This PR updates the GitHub Action version from `v3` to `v6` in `.github/workflows/markdownlint.yml`. The change ensures compatibility with the latest GitHub Actions features and improvements. The PR will be tested in the CI pipeline of the pull request.

