### PR TITLE
fix: pin 2 unpinned action(s)

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -6,7 +6,7 @@ jobs:
   labeler:
     runs-on: ubuntu-latest
     steps:
-      - uses: paulfantom/periodic-labeler@master
+      - uses: paulfantom/periodic-labeler@f47a62ac0749f9bdd8f81a1e0fedb253b8af1505 # master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -7,7 +7,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v6
     - name: Lint markdown
-      uses: DavidAnson/markdownlint-cli2-action@v19
+      uses: DavidAnson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265 # v19
       with:
         config: .markdownlint.yml
         globs: '*.md,translations/*.md,Comanche055/*.md,Luminary099/*.md'


### PR DESCRIPTION
> This is a re-submission of #968, which was closed due to a branch issue on my end. Same fixes, apologies for the noise.

## Security: Harden GitHub Actions workflows

Hey, I found some CI/CD security issues in this repo's GitHub Actions workflows. These are the same vulnerability classes that were exploited in the tj-actions/changed-files supply chain attack. I've been reviewing repos that are affected and submitting fixes where I can.

This PR applies mechanical fixes and flags anything else that needs a manual look. Happy to answer any questions.

### Fixes applied

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/label.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/markdownlint.yml` | Pinned 1 third-party action(s) to commit SHA |


### Additional findings (manual review recommended)

No additional findings beyond the fixes applied above.

### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks or reference unpinned third-party actions are vulnerable to code injection and supply chain attacks. These are the same vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-attack-and-its-impact) which compromised CI secrets across thousands of repositories.

### How to verify

Review the diff, each change is mechanical and preserves workflow behavior:
- **SHA pinning**: Pins third-party actions to immutable commit SHAs (original version tag preserved as comment)


---

If this PR is not welcome, just close it and I won't send another.